### PR TITLE
Move main API functions outside the classes

### DIFF
--- a/base/Ballerina.toml
+++ b/base/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "health.hl7v2"
-version = "1.0.1"
+version = "1.0.2"
 authors=["Ballerina"]
 keywords=["Healthcare", "HL7"]
 distribution = "2201.4.1"

--- a/base/Dependencies.toml
+++ b/base/Dependencies.toml
@@ -114,7 +114,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.hl7v2"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},

--- a/base/encoder.bal
+++ b/base/encoder.bal
@@ -17,27 +17,22 @@
 # HL7 Encoder interface.
 public type Encoder object {
     # Encode HL7 message model to encoded wire format.
-    # 
+    #
     # + message - HL7 message model
     # + return - encoded message. HL7Error if error occurred
     public isolated function encode(Message message) returns byte[]|HL7Error;
 };
 
-
-# HL7 message encoder.
-public isolated class HL7Encoder {
-    
-    # Encode HL7 message model to encoded wire format.
-    # 
-    # + hl7Version - Target HL7 version
-    # + message - HL7 message mnodel
-    # + return - encoded message. HL7Error if error occurred
-    public isolated function encode(string hl7Version, Message message) returns byte[]|HL7Error {
-        Encoder|HL7Error? encoder = check hl7Registry.getEncoder(hl7Version);
-        if encoder is Encoder {
-            return encoder.encode(message);
-        } else {
-            return error(HL7_V2_PARSER_ERROR, message = "Unable to find HL7 message encoder for HL7 version:" + hl7Version);
-        }
+# Encode HL7 message model to encoded wire format.
+#
+# + hl7Version - Target HL7 version
+# + message - HL7 message mnodel
+# + return - encoded message. HL7Error if error occurred
+public isolated function encode(string hl7Version, Message message) returns byte[]|HL7Error {
+    Encoder|HL7Error? encoder = check hl7Registry.getEncoder(hl7Version);
+    if encoder is Encoder {
+        return encoder.encode(message);
+    } else {
+        return error(HL7_V2_PARSER_ERROR, message = "Unable to find HL7 message encoder for HL7 version:" + hl7Version);
     }
 }

--- a/base/hl7_client.bal
+++ b/base/hl7_client.bal
@@ -21,8 +21,6 @@ public class HL7Client {
 
     final string host;
     final int port;
-    final HL7Parser parser = new ();
-    final HL7Encoder encoder = new ();
 
     public isolated function init(string remoteHost, int remotePort) returns HL7Error? {
 
@@ -40,11 +38,11 @@ public class HL7Client {
             if mshSegment is Segment {
                 anydata hl7Version = mshSegment.get("msh12");
                 if hl7Version is string {
-                    byte[]|HL7Error encodedMessage = self.encoder.encode(hl7Version, message);
+                    byte[]|HL7Error encodedMessage = encode(hl7Version, message);
                     if encodedMessage is byte[] {
                         byte[]|HL7Error response = self.writeToHL7Stream(encodedMessage);
                         if response is byte[] {
-                            Message|HL7Error parseResult = self.parser.parse(response);
+                            Message|HL7Error parseResult = parse(response);
                             if parseResult is HL7Error {
                                 return error HL7Error(HL7_V2_CLIENT_ERROR, parseResult, message = "Error occurred while parsing HL7 response message.");
                             }
@@ -59,7 +57,7 @@ public class HL7Client {
         } else {
             byte[]|HL7Error response = self.writeToHL7Stream(message);
             if response is byte[] {
-                Message|HL7Error parseResult = self.parser.parse(response);
+                Message|HL7Error parseResult = parse(response);
                 if parseResult is HL7Error {
                     return error HL7Error(HL7_V2_PARSER_ERROR, parseResult, message = "Error occurred while parsing HL7 response message.");
                 }

--- a/base/parser.bal
+++ b/base/parser.bal
@@ -19,34 +19,30 @@ public type Parser object {
     public isolated function parse(byte[] message) returns Message|HL7Error;
 };
 
-# HL7 message parser.
-public isolated class HL7Parser {
+# Parses HL7 message given the byte stream.
+# + message - HL7 Message in encoded wire format
+# + return - HL7 message model with specific type or GenericMessage model. HL7Error if error occurred
+public isolated function parse(string|byte[] message) returns Message|HL7Error {
 
-    # Parses HL7 message given the byte stream.
-    # + message - HL7 Message in encoded wire format
-    # + return - HL7 message model with specific type or GenericMessage model. HL7Error if error occurred
-    public isolated function parse(string|byte[] message) returns Message|HL7Error {
-
-        byte[] hL7WirePayload = [];
-        if message is string {
-            hL7WirePayload = createHL7WirePayload(string:toBytes(message));
-        } else {
-            hL7WirePayload = message;
-        } 
-        string|error msgStr = string:fromBytes(hL7WirePayload);
-        if msgStr is error {
-            return error(HL7_V2_PARSER_ERROR, message = "Failed to create string from byte array.");
-        }
-
-        string? hl7Version = extractHL7Version(msgStr);
-        if hl7Version is () {
-            return error(HL7_V2_PARSER_ERROR, message = "Failed to extract version of the HL7 message.");
-        }
-
-        Parser|HL7Error? parser = check hl7Registry.getParser(hl7Version);
-        if parser is HL7Error? {
-            return error(HL7_V2_PARSER_ERROR, message = "Unable to find parser for HL7 message with version:" + hl7Version);
-        }
-        return parser.parse(hL7WirePayload);
+    byte[] hL7WirePayload = [];
+    if message is string {
+        hL7WirePayload = createHL7WirePayload(string:toBytes(message));
+    } else {
+        hL7WirePayload = message;
     }
+    string|error msgStr = string:fromBytes(hL7WirePayload);
+    if msgStr is error {
+        return error(HL7_V2_PARSER_ERROR, message = "Failed to create string from byte array.");
+    }
+
+    string? hl7Version = extractHL7Version(msgStr);
+    if hl7Version is () {
+        return error(HL7_V2_PARSER_ERROR, message = "Failed to extract version of the HL7 message.");
+    }
+
+    Parser|HL7Error? parser = check hl7Registry.getParser(hl7Version);
+    if parser is HL7Error? {
+        return error(HL7_V2_PARSER_ERROR, message = "Unable to find parser for HL7 message with version:" + hl7Version);
+    }
+    return parser.parse(hL7WirePayload);
 }

--- a/hl7v23/Ballerina.toml
+++ b/hl7v23/Ballerina.toml
@@ -10,4 +10,4 @@ repository="https://github.com/ballerina-platform/module-ballerinax-health.hl7v2
 [[dependency]]
 org = "ballerinax"
 name = "health.hl7v2"
-version = "1.0.1"
+version = "1.0.2"

--- a/hl7v23/Dependencies.toml
+++ b/hl7v23/Dependencies.toml
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "health.hl7v2"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "regex"},


### PR DESCRIPTION
## Purpose
> $subject applies as per the best practices suggseted, since these methods are not using any states.