### PR TITLE
Implement CI-CD pipelines for hl7v2

### DIFF
--- a/.github/workflows/cd-hl7v2-base.yml
+++ b/.github/workflows/cd-hl7v2-base.yml
@@ -1,0 +1,127 @@
+name: CD hl7v2 Base
+
+on:
+  workflow_dispatch:
+    inputs:
+      bal_central_environment:
+        description: Ballerina Central Environment
+        type: choice
+        options:
+        - STAGE
+        - DEV
+        - PROD
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Ballerina Build hl7v2 Base
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            pack
+        env:
+          WORKING_DIR: ./base
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Push to Staging hl7v2 Base
+        if: github.event.inputs.bal_central_environment == 'STAGE'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./base
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_STAGE_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN }}
+
+      - name: Push to Dev hl7v2 Base
+        if: github.event.inputs.bal_central_environment == 'DEV'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./base
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_DEV_CENTRAL: true
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_DEV_ACCESS_TOKEN }}      
+
+      - name: Push to Prod hl7v2 Base
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args:
+            push
+        env:
+          WORKING_DIR: ./base
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+
+      - name: Publish Release
+        if: github.event.inputs.bal_central_environment == 'PROD'
+        id: publish_release
+        run: |
+          # Get Branch Name
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          # Release name
+          RELEASE_NAME=${BRANCH_NAME#release-}
+          curl \
+            -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "tag_name": "'$RELEASE_NAME'",
+              "name": "'$RELEASE_NAME'",
+              "body": "[Automated] Creating tag:  '$RELEASE_NAME'.",
+              "draft": false,
+              "prerelease": false
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/releases"
+
+      - name: Update version in Ballerina.toml
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        id: increment_patch_version
+        run: |
+          CURRENT_VERSION=$(grep -Po -m 1 '(?<=version = ")[\d.]+' ./base/Ballerina.toml)
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
+          PATCH_VERSION=$((VERSION_PARTS[2] + 1))
+          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$PATCH_VERSION-snapshot"
+          sed -i "s/version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" ./base/Ballerina.toml
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Commit changes and make a PR
+        if: ${{ github.event.inputs.bal_central_environment == 'PROD' }}
+        run: |
+          # Commit changes
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
+          git add ./base/Ballerina.toml
+          git commit -m "[Automated] Prepare hl7v2 Base for next dev cycle"
+          git push origin ${{ steps.publish_release.outputs.BRANCH_NAME }}
+          
+          # Set the base and head branches
+          BASE_BRANCH="main"
+          HEAD_BRANCH="${{ steps.publish_release.outputs.BRANCH_NAME }}"
+          # Create the pull request using the GitHub REST API
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d '{
+              "title": "[Automated] Prepare hl7v2 Base for next dev cycle",
+              "body": "",
+              "head": "'"$HEAD_BRANCH"'",
+              "base": "'"$BASE_BRANCH"'"
+            }' \
+            "https://api.github.com/repos/${{ github.repository }}/pulls")
+          # Extract the pull request URL from the response
+          PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+
+          echo "Pull Request created: $PR_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,121 @@
+name: CI
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+env:
+  HL7V2_PATTERN: '*/*'
+  GITHUB_WORKFLOWS_DIR: '.github'
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      project-matrix: ${{ steps.unique-project-paths.outputs.BALLERINA_PROJECT_PATHS }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Extract Unique Ballerina Project Paths from Changed Files
+        id: unique-project-paths
+        run: |
+          # Get changed files of PR from github API
+          PR_DETAILS=$(curl -sSL \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          CHANGED_FILES=$(echo "$PR_DETAILS" | jq -r '.[].filename')
+          echo "Changed Files: "
+          echo "${CHANGED_FILES}"
+
+          # Convert CHANGED_FILES to an array
+          readarray -t CHANGED_FILES_ARRAY <<<"${CHANGED_FILES}"
+          
+          # Remove duplicates from the CHANGED_FILES_ARRAY
+          declare -A UNIQUE_PATHS_MAP
+          for file in "${CHANGED_FILES_ARRAY[@]}"; do
+            if [[ $file == $HL7V2_PATTERN ]]; then
+              EXTRACTED_PATH=$(echo "$file" | cut -d '/' -f 1)
+            fi
+
+            if [[ $EXTRACTED_PATH && $EXTRACTED_PATH != $GITHUB_WORKFLOWS_DIR ]]; then
+              UNIQUE_PATHS_MAP[$EXTRACTED_PATH]=1
+            fi
+          done
+          
+          # Print the unique ballerina project paths
+          echo "Extracted Unique Ballerina Project Paths: "
+          for EXTRACTED_PATH in "${!UNIQUE_PATHS_MAP[@]}"; do
+            echo "$EXTRACTED_PATH"
+          done
+
+          # Create the JSON array with elements enclosed in double quotes
+          UNIQUE_PATHS_JSON=$(for key in "${!UNIQUE_PATHS_MAP[@]}"; do echo "\"$key\""; done | jq -s -c .)
+          echo "UNIQUE_PATHS_JSON: "
+          echo "${UNIQUE_PATHS_JSON}"
+          echo "BALLERINA_PROJECT_PATHS=${UNIQUE_PATHS_JSON}" >> $GITHUB_OUTPUT
+
+  build:
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    if: ${{ needs.setup.outputs.project-matrix != '[]' }}
+    strategy:
+      matrix:
+        path: ${{ fromJson(needs.setup.outputs.project-matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Ballerina Build
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args: pack
+        env:
+          WORKING_DIR: ./${{ matrix.path }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+  test:
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    env:
+      JAVA_OPTS: -Xmx4G
+    if: ${{ needs.setup.outputs.project-matrix != '[]' }}
+    strategy:
+      matrix:
+        path: ${{ fromJson(needs.setup.outputs.project-matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Ballerina Test
+        uses: ballerina-platform/ballerina-action@2201.6.0
+        with:
+          args: test --code-coverage
+        env:
+          WORKING_DIR: ./${{ matrix.path }}
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+
+      - name: Read Ballerina Test Results
+        id: test_results
+        run: |
+          if [ -f "./${{ matrix.path }}/target/report/test_results.json" ]; then
+            content=`cat ./${{ matrix.path }}/target/report/test_results.json`                
+            content="${content//'%'/'%25'}"
+            content="${content//$'\n'/'%0A'}"
+            content="${content//$'\r'/'%0D'}"
+
+            echo "Covered Code Lines : $(echo "$content" | jq -r '.coveredLines')"
+            echo "Total Code Lines : $(echo "$content" | jq -r '.missedLines') + $(echo "$content" | jq -r '.coveredLines')"
+            echo "Code Coverage Percentage : $(echo "$content" | jq -r '.coveragePercentage')"
+          else
+            # echo "TEST_RESULTS_JSON=" >> $GITHUB_OUTPUT
+            echo "No test results file found."
+          fi


### PR DESCRIPTION
Related Issue: https://github.com/wso2-enterprise/open-healthcare/issues/1200

## Purpose
> Implement CI-CD pipelines for hl7v2

## Goals
> Automate ballerina build and running tests on a PR
> Automate the release of ballerina artifacts to ballerina central's STAGE, DEV, and PROD environments

## Approach
> Implement a single CI workflow that triggers on every pull request and extracts the paths of all ballerina templates with changes from the respective pull request. This workflow handles the build process and executes unit tests for each identified template.
> Implement individual CD workflows for each Ballerina template, which can be manually triggered. These workflows are responsible for the building and releasing process to a chosen environment within Ballerina Central.

## Documentation
> https://docs.google.com/document/d/17-j7xDraMf_xO4B5_VziXpbmkgV_dPWypHONfxgkbRA/edit?usp=sharing 

## Concerns ( github action secrets required )
- BALLERINA_CENTRAL_STAGE_ACCESS_TOKEN <-- access token to publish an artifact to ballerina stage central
- BALLERINA_CENTRAL_DEV_ACCESS_TOKEN <-- access token to publish an artifact to ballerina development central
- BALLERINA_CENTRAL_PROD_ACCESS_TOKEN <-- access token to publish an artifact to ballerina production central
- BALLERINA_BOT_TOKEN <-- Personal access token with permission to write commits and creating PRs
- BALLERINA_BOT_USERNAME <-- username of github ballerina bot
- BALLERINA_BOT_EMAIL <-- email of github ballerina bot
