### PR TITLE
Multiple fixes for V2tofhir mappings

### DIFF
--- a/utils/v23tofhirr4/Dependencies.toml
+++ b/utils/v23tofhirr4/Dependencies.toml
@@ -41,10 +41,19 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.2"
+version = "2.11.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
+]
+
+[[package]]
+org = "ballerina"
+name = "data.csv"
+version = "0.8.2"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "log"}
 ]
 
 [[package]]
@@ -59,7 +68,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.5.2"
+version = "1.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -79,20 +88,23 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "ftp"
-version = "2.15.1"
+version = "2.17.1"
 dependencies = [
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "data.csv"},
 	{org = "ballerina", name = "data.jsondata"},
 	{org = "ballerina", name = "data.xmldata"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "task"}
+	{org = "ballerina", name = "task"},
+	{org = "ballerina", name = "time"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.8"
+version = "2.14.10"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -310,7 +322,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},
@@ -320,7 +332,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "tcp"
-version = "1.13.2"
+version = "1.13.4"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -396,7 +408,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "health.clients.fhir"
-version = "3.0.0"
+version = "3.0.6"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "ftp"},
@@ -415,7 +427,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "health.fhir.r4"
-version = "6.2.3"
+version = "6.3.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -436,7 +448,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.fhir.r4.international401"
-version = "4.0.0"
+version = "4.0.3"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "log"},
@@ -449,7 +461,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.fhir.r4.parser"
-version = "7.0.0"
+version = "7.1.1"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
@@ -466,7 +478,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.hl7v2"
-version = "3.0.5"
+version = "3.0.8"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},
@@ -480,7 +492,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "health.hl7v23"
-version = "4.0.1"
+version = "4.0.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},

--- a/utils/v23tofhirr4/datatypes_mappings.bal
+++ b/utils/v23tofhirr4/datatypes_mappings.bal
@@ -25,6 +25,14 @@ public isolated function ceToCodings(Ce ce) returns r4:Coding[]? {
     if ceToCodingResult != {} {
         codings.push(ceToCodingResult);
     }
+    r4:Coding alternateCoding = {
+        code: (ce.ce4 != "") ? ce.ce4 : (),
+        display: (ce.ce5 != "") ? ce.ce5 : (),
+        system: (ce.ce6 != "") ? ce.ce6 : ()
+    };
+    if alternateCoding != {} {
+        codings.push(alternateCoding);
+    }
     return (codings.length() > 0) ? codings : ();
 };
 
@@ -42,7 +50,29 @@ public isolated function xadToAddress(Xad xad) returns r4:Address? {
     r4:Extension[]? extension = [];
     string district = "";
 
-    extension = getStringExtension([xad.xad7, <string>xad.xad10]);
+    if xad.xad7 == "HV" {
+        extension = [
+            {
+                url: "http://hl7.org/fhir/StructureDefinition/iso21090-AD-use",
+                valueCode: xad.xad7
+            }
+        ];
+    }
+    if <string>xad.xad10 != "" {
+        if extension is r4:Extension[] {
+            extension.push({
+                url: "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
+                valueString: <string>xad.xad10
+            });
+        } else {
+            extension = [
+                {
+                    url: "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-censusTract",
+                    valueString: <string>xad.xad10
+                }
+            ];
+        }
+    }
     district = xad.xad9;
 
     r4:Address address = {
@@ -66,15 +96,22 @@ public isolated function xadToAddress(Xad xad) returns r4:Address? {
 };
 
 public isolated function xonToOrganization(Xon xon) returns international401:Organization {
-    string? xon3 = ();
-    xon3 = (xon.xon3 != "") ? xon.xon3.toString() : ();
+    string xon10 = "";
+    if xon.hasKey("xon10") {
+        anydata xon10Value = xon["xon10"];
+        if xon10Value is string {
+            xon10 = xon10Value;
+        }
+    }
+    string? identifierValue = ();
+    identifierValue = (xon10 != "") ? xon10 : ((xon.xon3 != "") ? xon.xon3.toString() : ());
     r4:Identifier identifier = {
-        value: xon3,
+        value: identifierValue,
         'type: (xon.xon7 != "") ? {
                 coding: [
                     {
                         code: xon.xon7,
-                        system: string `urn:oid: ${xon.xon7}`
+                        system: "http://terminology.hl7.org/CodeSystem/v2-0203"
                     }
                 ]
             } : ()
@@ -89,15 +126,22 @@ public isolated function xonToOrganization(Xon xon) returns international401:Org
 };
 
 public isolated function xonToReference(Xon xon) returns r4:Reference? {
-    string? xon3 = ();
-    xon3 = (xon.xon3 != "") ? xon.xon3.toString() : ();
+    string xon10 = "";
+    if xon.hasKey("xon10") {
+        anydata xon10Value = xon["xon10"];
+        if xon10Value is string {
+            xon10 = xon10Value;
+        }
+    }
+    string? identifierValue = ();
+    identifierValue = (xon10 != "") ? xon10 : ((xon.xon3 != "") ? xon.xon3.toString() : ());
     r4:Identifier identifier = {
-        value: xon3,
+        value: identifierValue,
         'type: (xon.xon7 != "") ? {
                 coding: [
                     {
                         code: xon.xon7,
-                        system: string `urn:oid: ${xon.xon7}`
+                        system: "http://terminology.hl7.org/CodeSystem/v2-0203"
                     }
                 ]
             } : ()
@@ -143,6 +187,13 @@ public isolated function xtnToContactPoint(Xtn xtn) returns r4:ContactPoint? {
     string xtn6 = xtn.xtn6.toString();
     string xtn7 = xtn.xtn7.toString();
     string xtn8 = xtn.xtn8.toString();
+    string xtn12 = "";
+    if xtn.hasKey("xtn12") {
+        anydata xtn12Value = xtn["xtn12"];
+        if xtn12Value is string {
+            xtn12 = xtn12Value;
+        }
+    }
     boolean isInternetOrX400 = xtn.xtn3 == "Internet" || xtn.xtn3 == "X.400";
 
     r4:StringExtension[] extensions = [];
@@ -172,14 +223,16 @@ public isolated function xtnToContactPoint(Xtn xtn) returns r4:ContactPoint? {
     }
 
     r4:ContactPoint contactPoint = {
-        use: idToContactPointUse(xtn.xtn2),
-        system: (xtn.xtn3 == "" && xtn.xtn4 != "") ? "email" : idToContactPointSystem(xtn.xtn3),
+        use: (xtn.xtn2 != "") ? idToContactPointUse(xtn.xtn2) : (),
+        system: (xtn.xtn3 == "" && xtn.xtn4 != "") ? "email" : ((xtn.xtn3 != "") ? idToContactPointSystem(xtn.xtn3) : ()),
         extension: (extensions.length() > 0) ? extensions : (),
         value: ()
     };
 
     if isInternetOrX400 && xtn.xtn4 != "" {
         contactPoint.value = xtn.xtn4;
+    } else if !isInternetOrX400 && xtn12 != "" {
+        contactPoint.value = xtn12;
     } else if !isInternetOrX400 && xtn7 == "" && xtn.xtn1 != "" {
         contactPoint.value = xtn.xtn1;
     } else if !isInternetOrX400 && xtn7 != "" {
@@ -201,31 +254,67 @@ public isolated function xtnToContactPoint(Xtn xtn) returns r4:ContactPoint? {
 
 public isolated function hdToMessageHeaderSource(Hd hd) returns international401:MessageHeaderSource {
     return {
-        name: (hd.hd1 != "") ? hd.hd1 : (),
-        endpoint: hd.hd2,
-        extension: getStringExtension([hd.hd3])
+        name: (hd.hd2 == "" && hd.hd1 != "") ? hd.hd1 : (),
+        endpoint: getHdEndpoint(hd)
     };
 };
 
 public isolated function hdToMessageHeaderDestination(Hd hd) returns international401:MessageHeaderDestination => {
-    name: (hd.hd1 != "") ? hd.hd1 : (),
-    endpoint: hd.hd2,
-    extension: getStringExtension([hd.hd3])
+    name: (hd.hd2 == "" && hd.hd1 != "") ? hd.hd1 : (),
+    endpoint: getHdEndpoint(hd)
 };
 
-public isolated function msgToCoding(hl7v23:CM_MSG msg) returns r4:Coding => {
-    code: (msg.cm_msg1 != "") ? msg.cm_msg1 : (),
-    system: (msg.cm_msg2 != "") ? msg.cm_msg2 : ()
+isolated function getHdEndpoint(Hd hd) returns r4:urlType {
+    match hd.hd3 {
+        "ISO" => {
+            return string `urn:oid:${hd.hd2}`;
+        }
+        "UUID" => {
+            return string `urn:uuid:${hd.hd2}`;
+        }
+        "DNS" => {
+            return string `urn:dns:${hd.hd2}`;
+        }
+        "URI" => {
+            return string `urn:uri:${hd.hd2}`;
+        }
+        _ => {
+            return hd.hd2;
+        }
+    }
+}
+
+public isolated function msgToCoding(hl7v23:CM_MSG msg) returns r4:Coding {
+    string cmMsg3 = "";
+    if msg.hasKey("cm_msg3") {
+        anydata cmMsg3Value = msg["cm_msg3"];
+        if cmMsg3Value is string {
+            cmMsg3 = cmMsg3Value;
+        }
+    }
+    return {
+        code: (msg.cm_msg1 != "") ? msg.cm_msg1 : (),
+        system: "http://terminology.hl7.org/CodeSystem/v2-0003",
+        display: (msg.cm_msg1 != "" || msg.cm_msg2 != "" || cmMsg3 != "") ? string `${msg.cm_msg1}^${msg.cm_msg2}^${cmMsg3}` : ()
+    };
 };
 
 public isolated function ptToMeta(Pt pt) returns r4:Meta {
+    r4:Coding[] tags = [];
+    if pt.pt1 != "" {
+        tags.push({
+            code: pt.pt1,
+            system: "http://terminology.hl7.org/CodeSystem/v2-0103"
+        });
+    }
+    if pt.pt2 != "" {
+        tags.push({
+            code: pt.pt2,
+            system: "http://terminology.hl7.org/CodeSystem/v2-0207"
+        });
+    }
     return {
-        tag: [
-            {
-                code: (pt.pt1 != "") ? pt.pt1 : (),
-                system: (pt.pt2 != "") ? pt.pt2 : ()
-            }
-        ]
+        tag: (tags.length() > 0) ? tags : ()
     };
 };
 
@@ -263,7 +352,7 @@ public isolated function ceToUri(Ce ce) returns r4:uri? {
 
 public isolated function xcnToCodeableConcept(Xcn xcn) returns r4:CodeableConcept {
     return {
-        id: (xcn.xcn1 != "") ? xcn.xcn1 : ()
+        coding: (xcn.xcn1 != "") ? [{code: xcn.xcn1}] : ()
     };
 };
 
@@ -281,7 +370,7 @@ public isolated function xcnToReferenceWithType(Xcn xcn, string resourceType) re
 
 public isolated function idToCoding(hl7v23:ID id) returns r4:Coding {
     return {
-        id: (id != "") ? id : ()
+        code: (id != "") ? id : ()
     };
 };
 
@@ -359,12 +448,50 @@ public type Ts hl7v23:TS;
 public type Is hl7v23:IS;
 
 public isolated function cxToIdentifier(Cx cx) returns r4:Identifier {
-    return {
+    string cx7 = "";
+    if cx.hasKey("cx7") {
+        anydata cx7Value = cx["cx7"];
+        if cx7Value is string {
+            cx7 = cx7Value;
+        }
+    }
+    string cx8 = "";
+    if cx.hasKey("cx8") {
+        anydata cx8Value = cx["cx8"];
+        if cx8Value is string {
+            cx8 = cx8Value;
+        }
+    }
+    r4:Identifier identifier = {
         value: (cx.cx1 != "") ? cx.cx1 : (),
         'type: (cx.cx5 != "") ? {
-            coding: [{code: cx.cx5}]
+            coding: [
+                {
+                    code: cx.cx5,
+                    system: "http://terminology.hl7.org/CodeSystem/v2-0203"
+                }
+            ]
+        } : (),
+        period: (cx7 != "" || cx8 != "") ? {
+            'start: (cx7 != "") ? hl7DateToFhir(cx7) : (),
+            end: (cx8 != "") ? hl7DateToFhir(cx8) : ()
         } : ()
     };
+    r4:Extension[] extensions = [];
+    if cx.cx2 != "" {
+        extensions.push({
+            url: "http://hl7.org/fhir/StructureDefinition/identifier-checkDigit",
+            valueString: cx.cx2
+        });
+    }
+    if cx.cx3 != "" {
+        extensions.push({
+            url: "http://hl7.org/fhir/StructureDefinition/namingsystem-checkDigit",
+            valueString: cx.cx3
+        });
+    }
+    identifier.extension = (extensions.length() > 0) ? extensions : ();
+    return identifier;
 };
 
 public isolated function xcnToHumanName(Xcn xcn) returns r4:HumanName {

--- a/utils/v23tofhirr4/datatypes_mappings.bal
+++ b/utils/v23tofhirr4/datatypes_mappings.bal
@@ -139,15 +139,59 @@ public isolated function xpnToHumanName(Xpn xpn) returns r4:HumanName {
 };
 
 public isolated function xtnToContactPoint(Xtn xtn) returns r4:ContactPoint? {
+    string xtn5 = xtn.xtn5.toString();
+    string xtn6 = xtn.xtn6.toString();
+    string xtn7 = xtn.xtn7.toString();
+    string xtn8 = xtn.xtn8.toString();
+    boolean isInternetOrX400 = xtn.xtn3 == "Internet" || xtn.xtn3 == "X.400";
+
+    r4:StringExtension[] extensions = [];
+    if xtn5 != "" {
+        extensions.push({
+            url: "http://hl7.org/fhir/StructureDefinition/contactpoint-country",
+            valueString: xtn5
+        });
+    }
+    if xtn6 != "" {
+        extensions.push({
+            url: "http://hl7.org/fhir/StructureDefinition/contactpoint-area",
+            valueString: xtn6
+        });
+    }
+    if !isInternetOrX400 && xtn7 != "" {
+        extensions.push({
+            url: "http://hl7.org/fhir/StructureDefinition/contactpoint-local",
+            valueString: xtn7
+        });
+    }
+    if xtn8 != "" {
+        extensions.push({
+            url: "http://hl7.org/fhir/StructureDefinition/contactpoint-extension",
+            valueString: xtn8
+        });
+    }
+
     r4:ContactPoint contactPoint = {
         use: idToContactPointUse(xtn.xtn2),
-        system: idToContactPointSystem(xtn.xtn3),
-        extension: xtn.xtn5 != "-1.0" ? getStringExtension([xtn.xtn5.toString()]) : (),
+        system: (xtn.xtn3 == "" && xtn.xtn4 != "") ? "email" : idToContactPointSystem(xtn.xtn3),
+        extension: (extensions.length() > 0) ? extensions : (),
         value: ()
     };
 
-    if (xtn.xtn3 != "Internet" || xtn.xtn3 != "X.400") && xtn.xtn7 != "" {
+    if isInternetOrX400 && xtn.xtn4 != "" {
+        contactPoint.value = xtn.xtn4;
+    } else if !isInternetOrX400 && xtn7 == "" && xtn.xtn1 != "" {
         contactPoint.value = xtn.xtn1;
+    } else if !isInternetOrX400 && xtn7 != "" {
+        if xtn5 != "" && xtn6 != "" && xtn8 != "" {
+            contactPoint.value = string `+${xtn5} ${xtn6} ${xtn7} X${xtn8}`;
+        } else if xtn5 != "" && xtn6 != "" {
+            contactPoint.value = string `+${xtn5} ${xtn6} ${xtn7}`;
+        } else if xtn6 != "" && xtn8 != "" {
+            contactPoint.value = string `${xtn6} ${xtn7} X${xtn8}`;
+        } else if xtn6 != "" {
+            contactPoint.value = string `${xtn6} ${xtn7}`;
+        }
     }
     if contactPoint.value == "" {
         return ();

--- a/utils/v23tofhirr4/datatypes_mappings.bal
+++ b/utils/v23tofhirr4/datatypes_mappings.bal
@@ -313,3 +313,37 @@ public type Ts hl7v23:TS;
 
 # Union type for IS data type for all supported hl7 versions.
 public type Is hl7v23:IS;
+
+public isolated function cxToIdentifier(Cx cx) returns r4:Identifier {
+    return {
+        value: (cx.cx1 != "") ? cx.cx1 : (),
+        'type: (cx.cx5 != "") ? {
+            coding: [{code: cx.cx5}]
+        } : ()
+    };
+};
+
+public isolated function xcnToHumanName(Xcn xcn) returns r4:HumanName {
+    r4:HumanName humanName = {};
+    humanName.family = (xcn.xcn2 != "") ? xcn.xcn2 : ();
+    if xcn.xcn3 != "" {
+        humanName.given = [xcn.xcn3];
+    }
+    if xcn.xcn5 != "" {
+        humanName.prefix = [xcn.xcn5];
+    }
+    return humanName;
+};
+
+public isolated function xcnToReferenceWithName(Xcn xcn, string resourceType) returns r4:Reference {
+    string? display = ();
+    if xcn.xcn2 != "" || xcn.xcn3 != "" {
+        display = ((xcn.xcn3 != "") ? xcn.xcn3 + " " : "") + xcn.xcn2;
+    } else if xcn.xcn1 != "" {
+        display = xcn.xcn1;
+    }
+    return {
+        reference: (xcn.xcn1 != "") ? string `${resourceType}/${xcn.xcn1}` : (),
+        display: display
+    };
+};

--- a/utils/v23tofhirr4/datatypes_mappings.bal
+++ b/utils/v23tofhirr4/datatypes_mappings.bal
@@ -382,7 +382,14 @@ public isolated function xcnToHumanName(Xcn xcn) returns r4:HumanName {
 public isolated function xcnToReferenceWithName(Xcn xcn, string resourceType) returns r4:Reference {
     string? display = ();
     if xcn.xcn2 != "" || xcn.xcn3 != "" {
-        display = ((xcn.xcn3 != "") ? xcn.xcn3 + " " : "") + xcn.xcn2;
+        string[] nameParts = [];
+        if xcn.xcn3 != "" {
+            nameParts.push(xcn.xcn3);
+        }
+        if xcn.xcn2 != "" {
+            nameParts.push(xcn.xcn2);
+        }
+        display = string:'join(" ", ...nameParts);
     } else if xcn.xcn1 != "" {
         display = xcn.xcn1;
     }

--- a/utils/v23tofhirr4/datatypes_mappings.bal
+++ b/utils/v23tofhirr4/datatypes_mappings.bal
@@ -25,12 +25,12 @@ public isolated function ceToCodings(Ce ce) returns r4:Coding[]? {
     if ceToCodingResult != {} {
         codings.push(ceToCodingResult);
     }
-    r4:Coding alternateCoding = {
-        code: (ce.ce4 != "") ? ce.ce4 : (),
-        display: (ce.ce5 != "") ? ce.ce5 : (),
-        system: (ce.ce6 != "") ? ce.ce6 : ()
-    };
-    if alternateCoding != {} {
+    if ce.ce4 != "" || ce.ce5 != "" || ce.ce6 != "" {
+        r4:Coding alternateCoding = {
+            code: (ce.ce4 != "") ? ce.ce4 : (),
+            display: (ce.ce5 != "") ? ce.ce5 : (),
+            system: (ce.ce6 != "") ? ce.ce6 : ()
+        };
         codings.push(alternateCoding);
     }
     return (codings.length() > 0) ? codings : ();
@@ -292,10 +292,24 @@ public isolated function msgToCoding(hl7v23:CM_MSG msg) returns r4:Coding {
             cmMsg3 = cmMsg3Value;
         }
     }
+    string[] displayParts = [];
+    if msg.cm_msg1 != "" {
+        displayParts.push(msg.cm_msg1);
+    }
+    if msg.cm_msg2 != "" {
+        displayParts.push(msg.cm_msg2);
+    }
+    if cmMsg3 != "" {
+        displayParts.push(cmMsg3);
+    }
+    string? display = ();
+    if displayParts.length() > 0 {
+        display = string:'join("^", ...displayParts);
+    }
     return {
         code: (msg.cm_msg1 != "") ? msg.cm_msg1 : (),
         system: "http://terminology.hl7.org/CodeSystem/v2-0003",
-        display: (msg.cm_msg1 != "" || msg.cm_msg2 != "" || cmMsg3 != "") ? string `${msg.cm_msg1}^${msg.cm_msg2}^${cmMsg3}` : ()
+        display: display
     };
 };
 

--- a/utils/v23tofhirr4/datatypes_mappings.bal
+++ b/utils/v23tofhirr4/datatypes_mappings.bal
@@ -47,7 +47,7 @@ public isolated function ceToCoding(Ce ce) returns r4:Coding => {
 };
 
 public isolated function xadToAddress(Xad xad) returns r4:Address? {
-    r4:Extension[]? extension = [];
+    r4:Extension[]? extension = ();
     string district = "";
 
     if xad.xad7 == "HV" {
@@ -84,7 +84,9 @@ public isolated function xadToAddress(Xad xad) returns r4:Address? {
         use: checkComputableAntlr([{identifier: xad.xad7, comparisonOperator: "IN", valueList: ["BA", "BI", "C", "B", "H", "O"]}]) ? idToAddressUse(xad.xad7) : (),
         district: (district != "") ? district : ()
     };
-    address.extension = extension;
+    if extension is r4:Extension[] && extension.length() > 0 {
+        address.extension = extension;
+    }
     if xad.xad1 != "" && xad.xad2 != "" {
         address.line = [xad.xad1, xad.xad2];
     } else if xad.xad1 != "" {
@@ -246,7 +248,7 @@ public isolated function xtnToContactPoint(Xtn xtn) returns r4:ContactPoint? {
             contactPoint.value = string `${xtn6} ${xtn7}`;
         }
     }
-    if contactPoint.value == "" {
+    if contactPoint.value == () || contactPoint.value == "" || contactPoint == {} {
         return ();
     }
     return contactPoint;
@@ -265,6 +267,9 @@ public isolated function hdToMessageHeaderDestination(Hd hd) returns internation
 };
 
 isolated function getHdEndpoint(Hd hd) returns r4:urlType {
+    if hd.hd2 == "" {
+        return hd.hd1;
+    }
     match hd.hd3 {
         "ISO" => {
             return string `urn:oid:${hd.hd2}`;

--- a/utils/v23tofhirr4/datatypes_mappings.bal
+++ b/utils/v23tofhirr4/datatypes_mappings.bal
@@ -42,10 +42,8 @@ public isolated function xadToAddress(Xad xad) returns r4:Address? {
     r4:Extension[]? extension = [];
     string district = "";
 
-    if xad is hl7v23:XAD {
-        extension = getStringExtension([xad.xad7, <string>xad.xad10]);
-        district = xad.xad9;
-    }
+    extension = getStringExtension([xad.xad7, <string>xad.xad10]);
+    district = xad.xad9;
 
     r4:Address address = {
         city: (xad.xad3 != "") ? xad.xad3 : (),
@@ -57,23 +55,19 @@ public isolated function xadToAddress(Xad xad) returns r4:Address? {
         district: (district != "") ? district : ()
     };
     address.extension = extension;
-    if xad is hl7v23:XAD {
-        if xad.xad1 != "" && xad.xad2 != "" {
-            address.line = [xad.xad1, xad.xad2];
-        } else if xad.xad1 != "" {
-            address.line = [xad.xad1];
-        } else if xad.xad2 != "" {
-            address.line = [xad.xad2];
-        }
+    if xad.xad1 != "" && xad.xad2 != "" {
+        address.line = [xad.xad1, xad.xad2];
+    } else if xad.xad1 != "" {
+        address.line = [xad.xad1];
+    } else if xad.xad2 != "" {
+        address.line = [xad.xad2];
     }
     return (address != {}) ? address : ();
 };
 
 public isolated function xonToOrganization(Xon xon) returns international401:Organization {
     string? xon3 = ();
-    if xon is hl7v23:XON {
-        xon3 = (xon.xon3 != "") ? xon.xon3.toString() : ();
-    }
+    xon3 = (xon.xon3 != "") ? xon.xon3.toString() : ();
     r4:Identifier identifier = {
         value: xon3,
         'type: (xon.xon7 != "") ? {
@@ -96,9 +90,7 @@ public isolated function xonToOrganization(Xon xon) returns international401:Org
 
 public isolated function xonToReference(Xon xon) returns r4:Reference? {
     string? xon3 = ();
-    if xon is hl7v23:XON {
-        xon3 = (xon.xon3 != "") ? xon.xon3.toString() : ();
-    }
+    xon3 = (xon.xon3 != "") ? xon.xon3.toString() : ();
     r4:Identifier identifier = {
         value: xon3,
         'type: (xon.xon7 != "") ? {
@@ -120,9 +112,7 @@ public isolated function xpnToHumanName(Xpn xpn) returns r4:HumanName {
     r4:HumanName humanName = {
         use: (xpn.xpn7 != "") ? idToHumanNameUse(xpn.xpn7) : ()
     };
-    if xpn is hl7v23:XPN {
-        humanName.family = (xpn.xpn1 != "") ? xpn.xpn1 : ();
-    }
+    humanName.family = (xpn.xpn1 != "") ? xpn.xpn1 : ();
     //given
     if xpn.xpn2 != "" && xpn.xpn3 != "" {
         humanName.given = [xpn.xpn2, xpn.xpn3];
@@ -133,9 +123,7 @@ public isolated function xpnToHumanName(Xpn xpn) returns r4:HumanName {
     }
     //suffix
     string[] suffix = [];
-    if xpn is hl7v23:XPN {
-        suffix = [xpn.xpn4, xpn.xpn6];
-    }
+    suffix = [xpn.xpn4, xpn.xpn6];
     if suffix[0] != "" && suffix[1] != "" {
         humanName.suffix = suffix;
     } else if suffix[0] != "" {
@@ -158,10 +146,8 @@ public isolated function xtnToContactPoint(Xtn xtn) returns r4:ContactPoint? {
         value: ()
     };
 
-    if xtn is hl7v23:XTN {
-        if (xtn.xtn3 != "Internet" || xtn.xtn3 != "X.400") && xtn.xtn7 != "" {
-            contactPoint.value = xtn.xtn1;
-        }
+    if (xtn.xtn3 != "Internet" || xtn.xtn3 != "X.400") && xtn.xtn7 != "" {
+        contactPoint.value = xtn.xtn1;
     }
     if contactPoint.value == "" {
         return ();

--- a/utils/v23tofhirr4/mapping_defs.bal
+++ b/utils/v23tofhirr4/mapping_defs.bal
@@ -65,27 +65,113 @@ public type Pv2ToEncounter isolated function (Pv2 pv2) returns international401:
 # Mapping function type for ORC segment to Immunization FHIR resource.
 public type OrcToImmunization isolated function (Orc orc) returns international401:Immunization;
 
+# Mapping function type for NK1 segment to RelatedPerson FHIR resource.
+public type Nk1ToRelatedPerson isolated function (Nk1 nk1) returns international401:RelatedPerson;
+
+# Mapping function type for NTE segment to Observation FHIR resource.
+public type NteToObservation isolated function (Nte nte) returns international401:Observation;
+
+# Mapping function type for ORC segment to ServiceRequest FHIR resource.
+public type OrcToServiceRequest isolated function (Orc orc) returns international401:ServiceRequest;
+
+# Mapping function type for OBR segment to ServiceRequest FHIR resource.
+public type ObrToServiceRequest isolated function (Obr obr) returns international401:ServiceRequest;
+
+# Mapping function type for PR1 segment to Procedure FHIR resource.
+public type Pr1ToProcedure isolated function (Pr1 pr1) returns international401:Procedure;
+
+# Mapping function type for RXA segment to Immunization FHIR resource.
+public type RxaToImmunization isolated function (Rxa rxa) returns international401:Immunization;
+
+# Mapping function type for RXO segment to MedicationRequest FHIR resource.
+public type RxoToMedicationRequest isolated function (Rxo rxo) returns international401:MedicationRequest;
+
+# Mapping function type for RXR segment to Immunization FHIR resource.
+public type RxrToImmunization isolated function (Rxr rxr) returns international401:Immunization;
+
+# Mapping function type for RXR segment to MedicationRequest FHIR resource.
+public type RxrToMedicationRequest isolated function (Rxr rxr) returns international401:MedicationRequest;
+
+# Mapping function type for SCH segment to Appointment FHIR resource.
+public type SchToAppointment isolated function (Sch sch) returns international401:Appointment;
+
+# Mapping function type for TXA segment to DocumentReference FHIR resource.
+public type TxaToDocumentReference isolated function (Txa txa) returns international401:DocumentReference;
+
+# Mapping function type for ROL segment to RelatedPerson FHIR resource.
+public type RolToRelatedPerson isolated function (Rol rol) returns international401:RelatedPerson;
+
+# Mapping function type for MSA segment to MessageHeader FHIR resource.
+public type MsaToMessageHeader isolated function (Msa msa) returns international401:MessageHeader;
+
+# Mapping function type for MRG segment to Account FHIR resource.
+public type MrgToAccount isolated function (Mrg mrg) returns international401:Account;
+
+# Mapping function type for IN1 segment to Coverage FHIR resource.
+public type In1ToCoverage isolated function (In1 in1) returns international401:Coverage;
+
+# Mapping function type for IN3 segment to CareTeam FHIR resource.
+public type In3ToCareTeam isolated function (In3 in3) returns international401:CareTeam;
+
+# Mapping function type for PV1 segment to Coverage FHIR resource.
+public type Pv1ToCoverage isolated function (Pv1 pv1) returns international401:Coverage;
+
+# Mapping function type for AIG segment to Appointment FHIR resource.
+public type AigToAppointment isolated function (Aig aig) returns international401:Appointment;
+
+# Mapping function type for AIL segment to Appointment FHIR resource.
+public type AilToAppointment isolated function (Ail ail) returns international401:Appointment;
+
+# Mapping function type for AIP segment to Appointment FHIR resource.
+public type AipToAppointment isolated function (Aip aip) returns international401:Appointment;
+
+# Mapping function type for AIS segment to Appointment FHIR resource.
+public type AisToAppointment isolated function (Ais ais) returns international401:Appointment;
+
 # V2toFHIR Mapper function implementation holder record.
 #
-# + pv1ToPatient - PV1 segment to Patient FHIR resource mapping function  
-# + pv1ToEncounter - PV1 segment to Encounter FHIR resource mapping function  
-# + nk1ToPatient - NK1 segment to Patient FHIR resource mapping function 
-# + pd1ToPatient - PD1 segment to Patient FHIR resource mapping function  
-# + pidToPatient - PID segment to Patient FHIR resource mapping function  
+# + pv1ToPatient - PV1 segment to Patient FHIR resource mapping function
+# + pv1ToEncounter - PV1 segment to Encounter FHIR resource mapping function
+# + pv1ToCoverage - PV1 segment to Coverage FHIR resource mapping function
+# + nk1ToPatient - NK1 segment to Patient FHIR resource mapping function
+# + nk1ToRelatedPerson - NK1 segment to RelatedPerson FHIR resource mapping function
+# + pd1ToPatient - PD1 segment to Patient FHIR resource mapping function
+# + pidToPatient - PID segment to Patient FHIR resource mapping function
 # + dg1ToCondition - DG1 segment to Condition FHIR resource mapping function
 # + dg1ToEncounter - DG1 segment to Encounter FHIR resource mapping function
-# + dg1ToEpisodeOfCare - DG1 segment to EpisodeOfCare FHIR resource mapping function  
-# + obxToObservation - OBX segment to Observation FHIR resource mapping function  
-# + obrToDiagnosticReport - OBR segment to DiagnosticReport FHIR resource mapping function  
-# + al1ToAllerygyIntolerance - AL1 segment to AllergyIntolerance FHIR resource mapping function  
-# + evnToProvenance - EVN segment to Provenance FHIR resource mapping function  
-# + mshToMessageHeader - MSH segment to MessageHeader FHIR resource mapping function  
-# + pv2ToEncounter - PV2 segment to Encounter FHIR resource mapping function  
+# + dg1ToEpisodeOfCare - DG1 segment to EpisodeOfCare FHIR resource mapping function
+# + obxToObservation - OBX segment to Observation FHIR resource mapping function
+# + obrToDiagnosticReport - OBR segment to DiagnosticReport FHIR resource mapping function
+# + obrToServiceRequest - OBR segment to ServiceRequest FHIR resource mapping function
+# + al1ToAllerygyIntolerance - AL1 segment to AllergyIntolerance FHIR resource mapping function
+# + evnToProvenance - EVN segment to Provenance FHIR resource mapping function
+# + mshToMessageHeader - MSH segment to MessageHeader FHIR resource mapping function
+# + pv2ToEncounter - PV2 segment to Encounter FHIR resource mapping function
 # + orcToImmunization - ORC segment to Immunization FHIR resource mapping function
+# + orcToServiceRequest - ORC segment to ServiceRequest FHIR resource mapping function
+# + nteToObservation - NTE segment to Observation FHIR resource mapping function
+# + pr1ToProcedure - PR1 segment to Procedure FHIR resource mapping function
+# + rxaToImmunization - RXA segment to Immunization FHIR resource mapping function
+# + rxoToMedicationRequest - RXO segment to MedicationRequest FHIR resource mapping function
+# + rxrToImmunization - RXR segment to Immunization FHIR resource mapping function
+# + rxrToMedicationRequest - RXR segment to MedicationRequest FHIR resource mapping function
+# + schToAppointment - SCH segment to Appointment FHIR resource mapping function
+# + txaToDocumentReference - TXA segment to DocumentReference FHIR resource mapping function
+# + rolToRelatedPerson - ROL segment to RelatedPerson FHIR resource mapping function
+# + msaToMessageHeader - MSA segment to MessageHeader FHIR resource mapping function
+# + mrgToAccount - MRG segment to Account FHIR resource mapping function
+# + in1ToCoverage - IN1 segment to Coverage FHIR resource mapping function
+# + in3ToCareTeam - IN3 segment to CareTeam FHIR resource mapping function
+# + aigToAppointment - AIG segment to Appointment FHIR resource mapping function
+# + ailToAppointment - AIL segment to Appointment FHIR resource mapping function
+# + aipToAppointment - AIP segment to Appointment FHIR resource mapping function
+# + aisToAppointment - AIS segment to Appointment FHIR resource mapping function
 public type V2SegmentToFhirMapper record {
     Pv1ToPatient pv1ToPatient?;
     Pv1ToEncounter pv1ToEncounter?;
+    Pv1ToCoverage pv1ToCoverage?;
     Nk1ToPatient nk1ToPatient?;
+    Nk1ToRelatedPerson nk1ToRelatedPerson?;
     Pd1ToPatient pd1ToPatient?;
     PidToPatient pidToPatient?;
     Dg1ToCondition dg1ToCondition?;
@@ -93,18 +179,39 @@ public type V2SegmentToFhirMapper record {
     Dg1ToEpisodeOfCare dg1ToEpisodeOfCare?;
     ObxToObservation obxToObservation?;
     ObrToDiagnosticReport obrToDiagnosticReport?;
+    ObrToServiceRequest obrToServiceRequest?;
     Al1ToAllerygyIntolerance al1ToAllerygyIntolerance?;
     EvnToProvenance evnToProvenance?;
     MshToMessageHeader mshToMessageHeader?;
     Pv2ToEncounter pv2ToEncounter?;
     OrcToImmunization orcToImmunization?;
+    OrcToServiceRequest orcToServiceRequest?;
+    NteToObservation nteToObservation?;
+    Pr1ToProcedure pr1ToProcedure?;
+    RxaToImmunization rxaToImmunization?;
+    RxoToMedicationRequest rxoToMedicationRequest?;
+    RxrToImmunization rxrToImmunization?;
+    RxrToMedicationRequest rxrToMedicationRequest?;
+    SchToAppointment schToAppointment?;
+    TxaToDocumentReference txaToDocumentReference?;
+    RolToRelatedPerson rolToRelatedPerson?;
+    MsaToMessageHeader msaToMessageHeader?;
+    MrgToAccount mrgToAccount?;
+    In1ToCoverage in1ToCoverage?;
+    In3ToCareTeam in3ToCareTeam?;
+    AigToAppointment aigToAppointment?;
+    AilToAppointment ailToAppointment?;
+    AipToAppointment aipToAppointment?;
+    AisToAppointment aisToAppointment?;
 };
 
 // Record initialized with the default mapping functions.
 final readonly & V2SegmentToFhirMapper defaultMapper = {
     pv1ToPatient,
     pv1ToEncounter,
+    pv1ToCoverage,
     nk1ToPatient,
+    nk1ToRelatedPerson,
     pd1ToPatient,
     pidToPatient,
     dg1ToCondition,
@@ -112,10 +219,29 @@ final readonly & V2SegmentToFhirMapper defaultMapper = {
     dg1ToEpisodeOfCare,
     obxToObservation,
     obrToDiagnosticReport,
+    obrToServiceRequest,
     al1ToAllerygyIntolerance,
     evnToProvenance,
     mshToMessageHeader,
     pv2ToEncounter,
-    orcToImmunization
+    orcToImmunization,
+    orcToServiceRequest,
+    nteToObservation,
+    pr1ToProcedure,
+    rxaToImmunization,
+    rxoToMedicationRequest,
+    rxrToImmunization,
+    rxrToMedicationRequest,
+    schToAppointment,
+    txaToDocumentReference,
+    rolToRelatedPerson,
+    msaToMessageHeader,
+    mrgToAccount,
+    in1ToCoverage,
+    in3ToCareTeam,
+    aigToAppointment,
+    ailToAppointment,
+    aipToAppointment,
+    aisToAppointment
 };
 

--- a/utils/v23tofhirr4/mappings.bal
+++ b/utils/v23tofhirr4/mappings.bal
@@ -64,13 +64,22 @@ public isolated function segmentToFhir(string segmentName, hl7:Segment segment, 
     }
     match segmentName {
         "NK1" => {
-            Nk1ToPatient? nk1ToPatient = impl.nk1ToPatient;
-            if nk1ToPatient is Nk1ToPatient {
-                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
-                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
-                if customMappingResponse[0] {
-                    constructedResource = nk1ToPatient(check segment.ensureType(Nk1));
+            [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+            if customMappingResponse[0] {
+                Nk1ToPatient? nk1ToPatient = impl.nk1ToPatient;
+                if nk1ToPatient is Nk1ToPatient {
+                    map<anydata> constructedResource = nk1ToPatient(check segment.ensureType(Nk1));
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
+                    entries.push(...bundleEntriesResult);
                 }
+                Nk1ToRelatedPerson? nk1ToRelatedPerson = impl.nk1ToRelatedPerson;
+                if nk1ToRelatedPerson is Nk1ToRelatedPerson {
+                    map<anydata> constructedResource = nk1ToRelatedPerson(check segment.ensureType(Nk1));
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
+                    entries.push(...bundleEntriesResult);
+                }
+            } else {
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
                 return populateBundleEntries(constructedResource);
             }
         }
@@ -107,6 +116,11 @@ public isolated function segmentToFhir(string segmentName, hl7:Segment segment, 
                 Pv1ToEncounter? pv1ToEncounterResult = impl.pv1ToEncounter;
                 if pv1ToEncounterResult is Pv1ToEncounter {
                     r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(pv1ToEncounterResult(check segment.ensureType(Pv1)));
+                    entries.push(...bundleEntriesResult);
+                }
+                Pv1ToCoverage? pv1ToCoverageResult = impl.pv1ToCoverage;
+                if pv1ToCoverageResult is Pv1ToCoverage {
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(pv1ToCoverageResult(check segment.ensureType(Pv1)));
                     entries.push(...bundleEntriesResult);
                 }
             }
@@ -202,31 +216,229 @@ public isolated function segmentToFhir(string segmentName, hl7:Segment segment, 
             }
         }
         "ORC" => {
-            OrcToImmunization? orcToImmunization = impl.orcToImmunization;
-            if orcToImmunization is OrcToImmunization {
-                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
-                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
-                if customMappingResponse[0] {
-                    constructedResource = orcToImmunization(check segment.ensureType(Orc));
+            [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+            if customMappingResponse[0] {
+                OrcToImmunization? orcToImmunization = impl.orcToImmunization;
+                if orcToImmunization is OrcToImmunization {
+                    map<anydata> constructedResource = orcToImmunization(check segment.ensureType(Orc));
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
+                    entries.push(...bundleEntriesResult);
                 }
+                OrcToServiceRequest? orcToServiceRequest = impl.orcToServiceRequest;
+                if orcToServiceRequest is OrcToServiceRequest {
+                    map<anydata> constructedResource = orcToServiceRequest(check segment.ensureType(Orc));
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
+                    entries.push(...bundleEntriesResult);
+                }
+            } else {
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
                 return populateBundleEntries(constructedResource);
             }
         }
         "OBR" => {
-            ObrToDiagnosticReport? obrToDiagnosticReport = impl.obrToDiagnosticReport;
-            if obrToDiagnosticReport is ObrToDiagnosticReport {
-                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
-                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
-                if customMappingResponse[0] {
-                    constructedResource = obrToDiagnosticReport(check segment.ensureType(Obr));
+            [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+            if customMappingResponse[0] {
+                ObrToDiagnosticReport? obrToDiagnosticReport = impl.obrToDiagnosticReport;
+                if obrToDiagnosticReport is ObrToDiagnosticReport {
+                    map<anydata> constructedResource = obrToDiagnosticReport(check segment.ensureType(Obr));
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
+                    entries.push(...bundleEntriesResult);
                 }
+                ObrToServiceRequest? obrToServiceRequest = impl.obrToServiceRequest;
+                if obrToServiceRequest is ObrToServiceRequest {
+                    map<anydata> constructedResource = obrToServiceRequest(check segment.ensureType(Obr));
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
+                    entries.push(...bundleEntriesResult);
+                }
+            } else {
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
                 return populateBundleEntries(constructedResource);
             }
         }
         "NTE" => {
-            // Skip NTE segment tempararily. Tracking issue: https://github.com/wso2-enterprise/open-healthcare/issues/1737
-            r4:BundleEntry[] entriesNew = [];
-            return entriesNew;
+            NteToObservation? nteToObservation = impl.nteToObservation;
+            if nteToObservation is NteToObservation {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = nteToObservation(check segment.ensureType(Nte));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "PR1" => {
+            Pr1ToProcedure? pr1ToProcedure = impl.pr1ToProcedure;
+            if pr1ToProcedure is Pr1ToProcedure {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = pr1ToProcedure(check segment.ensureType(Pr1));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "RXA" => {
+            RxaToImmunization? rxaToImmunization = impl.rxaToImmunization;
+            if rxaToImmunization is RxaToImmunization {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = rxaToImmunization(check segment.ensureType(Rxa));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "RXO" => {
+            RxoToMedicationRequest? rxoToMedicationRequest = impl.rxoToMedicationRequest;
+            if rxoToMedicationRequest is RxoToMedicationRequest {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = rxoToMedicationRequest(check segment.ensureType(Rxo));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "RXR" => {
+            [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+            if customMappingResponse[0] {
+                RxrToImmunization? rxrToImmunization = impl.rxrToImmunization;
+                if rxrToImmunization is RxrToImmunization {
+                    map<anydata> constructedResource = rxrToImmunization(check segment.ensureType(Rxr));
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
+                    entries.push(...bundleEntriesResult);
+                }
+                RxrToMedicationRequest? rxrToMedicationRequest = impl.rxrToMedicationRequest;
+                if rxrToMedicationRequest is RxrToMedicationRequest {
+                    map<anydata> constructedResource = rxrToMedicationRequest(check segment.ensureType(Rxr));
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
+                    entries.push(...bundleEntriesResult);
+                }
+            } else {
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "SCH" => {
+            SchToAppointment? schToAppointment = impl.schToAppointment;
+            if schToAppointment is SchToAppointment {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = schToAppointment(check segment.ensureType(Sch));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "TXA" => {
+            TxaToDocumentReference? txaToDocumentReference = impl.txaToDocumentReference;
+            if txaToDocumentReference is TxaToDocumentReference {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = txaToDocumentReference(check segment.ensureType(Txa));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "ROL" => {
+            RolToRelatedPerson? rolToRelatedPerson = impl.rolToRelatedPerson;
+            if rolToRelatedPerson is RolToRelatedPerson {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = rolToRelatedPerson(check segment.ensureType(Rol));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "MSA" => {
+            MsaToMessageHeader? msaToMessageHeader = impl.msaToMessageHeader;
+            if msaToMessageHeader is MsaToMessageHeader {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = msaToMessageHeader(check segment.ensureType(Msa));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "MRG" => {
+            MrgToAccount? mrgToAccount = impl.mrgToAccount;
+            if mrgToAccount is MrgToAccount {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = mrgToAccount(check segment.ensureType(Mrg));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "IN1" => {
+            In1ToCoverage? in1ToCoverage = impl.in1ToCoverage;
+            if in1ToCoverage is In1ToCoverage {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = in1ToCoverage(check segment.ensureType(In1));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "IN3" => {
+            In3ToCareTeam? in3ToCareTeam = impl.in3ToCareTeam;
+            if in3ToCareTeam is In3ToCareTeam {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = in3ToCareTeam(check segment.ensureType(In3));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "AIG" => {
+            AigToAppointment? aigToAppointment = impl.aigToAppointment;
+            if aigToAppointment is AigToAppointment {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = aigToAppointment(check segment.ensureType(Aig));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "AIL" => {
+            AilToAppointment? ailToAppointment = impl.ailToAppointment;
+            if ailToAppointment is AilToAppointment {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = ailToAppointment(check segment.ensureType(Ail));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "AIP" => {
+            AipToAppointment? aipToAppointment = impl.aipToAppointment;
+            if aipToAppointment is AipToAppointment {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = aipToAppointment(check segment.ensureType(Aip));
+                }
+                return populateBundleEntries(constructedResource);
+            }
+        }
+        "AIS" => {
+            AisToAppointment? aisToAppointment = impl.aisToAppointment;
+            if aisToAppointment is AisToAppointment {
+                [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
+                map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
+                if customMappingResponse[0] {
+                    constructedResource = aisToAppointment(check segment.ensureType(Ais));
+                }
+                return populateBundleEntries(constructedResource);
+            }
         }
         _ => {
             if segmentName.length() == 3 {
@@ -860,7 +1072,7 @@ public isolated function obrToDiagnosticReport(Obr obr) returns international401
     return diagnosticReport;
 };
 
-public function obrToServiceRequest(Obr obr) returns international401:ServiceRequest {
+public isolated function obrToServiceRequest(Obr obr) returns international401:ServiceRequest {
     international401:ServiceRequest serviceRequest = {
         intent: nameToServiceRequestIntent(obr.name),
         priority: idToServiceRequestPriority(obr.obr5),
@@ -978,4 +1190,907 @@ public isolated function orcToImmunization(Orc orc) returns international401:Imm
     immunization.recorded = tsToDateTime(orc.orc9);
 
     return immunization;
+};
+
+// --------------------------------------------------------------------------------------------#
+// NK1 → RelatedPerson
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-nk1-to-relatedperson.html
+// --------------------------------------------------------------------------------------------#
+public isolated function nk1ToRelatedPerson(Nk1 nk1) returns international401:RelatedPerson {
+    international401:RelatedPerson relatedPerson = {
+        patient: {}
+    };
+
+    r4:HumanName[] names = [];
+    foreach hl7v23:XPN item in nk1.nk12 {
+        r4:HumanName name = xpnToHumanName(item);
+        if name != {} {
+            names.push(name);
+        }
+    }
+    foreach hl7v23:XPN item in nk1.nk130 {
+        r4:HumanName name = xpnToHumanName(item);
+        if name != {} {
+            names.push(name);
+        }
+    }
+    relatedPerson.name = (names.length() > 0) ? names : ();
+
+    r4:CodeableConcept[] relationship = [];
+    r4:CodeableConcept rel = ceToCodeableConcept(nk1.nk13);
+    if rel != {} {
+        relationship.push(rel);
+    }
+    r4:CodeableConcept contactRole = ceToCodeableConcept(nk1.nk17);
+    if contactRole != {} {
+        relationship.push(contactRole);
+    }
+    relatedPerson.relationship = (relationship.length() > 0) ? relationship : ();
+
+    r4:Address[] addresses = [];
+    foreach hl7v23:XAD item in nk1.nk14 {
+        r4:Address? addr = xadToAddress(item);
+        if addr is r4:Address {
+            addresses.push(addr);
+        }
+    }
+    foreach hl7v23:XAD item in nk1.nk132 {
+        r4:Address? addr = xadToAddress(item);
+        if addr is r4:Address {
+            addresses.push(addr);
+        }
+    }
+    relatedPerson.address = (addresses.length() > 0) ? addresses : ();
+
+    r4:ContactPoint[] telecoms = [];
+    foreach hl7v23:XTN item in nk1.nk15 {
+        r4:ContactPoint? cp = xtnToContactPoint(item);
+        if cp is r4:ContactPoint {
+            telecoms.push(cp);
+        }
+    }
+    foreach hl7v23:XTN item in nk1.nk16 {
+        r4:ContactPoint? cp = xtnToContactPoint(item);
+        if cp is r4:ContactPoint {
+            telecoms.push(cp);
+        }
+    }
+    foreach hl7v23:XTN item in nk1.nk131 {
+        r4:ContactPoint? cp = xtnToContactPoint(item);
+        if cp is r4:ContactPoint {
+            telecoms.push(cp);
+        }
+    }
+    relatedPerson.telecom = (telecoms.length() > 0) ? telecoms : ();
+
+    r4:Period period = {'start: nk1.nk18 != "" ? nk1.nk18 : (), end: nk1.nk19 != "" ? nk1.nk19 : ()};
+    if period != {} {
+        relatedPerson.period = period;
+    }
+
+    relatedPerson.gender = pidToAdministrativeSex(nk1.nk115);
+    relatedPerson.birthDate = (nk1.nk116.ts1 != "") ? hl7DateToFhir(nk1.nk116.ts1) : ();
+
+    r4:Identifier[] identifiers = [];
+    r4:Identifier empId = cxToIdentifier(nk1.nk112);
+    if empId != {} {
+        identifiers.push(empId);
+    }
+    foreach hl7v23:CX item in nk1.nk133 {
+        r4:Identifier id = cxToIdentifier(item);
+        if id != {} {
+            identifiers.push(id);
+        }
+    }
+    if nk1.nk137 != "" {
+        identifiers.push({
+            value: nk1.nk137,
+            system: "http://hl7.org/fhir/sid/us-ssn",
+            'type: {coding: [{code: "SS", system: "http://terminology.hl7.org/CodeSystem/v2-0203"}]}
+        });
+    }
+    relatedPerson.identifier = (identifiers.length() > 0) ? identifiers : ();
+
+    r4:CodeableConcept? lang = ceToCodeableConcept(nk1.nk120);
+    if lang is r4:CodeableConcept && lang != {} {
+        relatedPerson.communication = [{language: lang}];
+    }
+
+    return relatedPerson;
+};
+
+// --------------------------------------------------------------------------------------------#
+// NTE → Observation
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-nte-to-observation.html
+// Note: HL7v2.3 NTE segment only has nte3 (comment text); nte5/nte6 fields are v2.6+
+// --------------------------------------------------------------------------------------------#
+public isolated function nteToObservation(Nte nte) returns international401:Observation {
+    r4:Annotation[] notes = [];
+    foreach hl7v23:FT commentLine in nte.nte3 {
+        if commentLine != "" {
+            notes.push({text: commentLine});
+        }
+    }
+    international401:Observation observation = {
+        code: {},
+        status: "preliminary",
+        note: (notes.length() > 0) ? notes : ()
+    };
+    return observation;
+};
+
+// --------------------------------------------------------------------------------------------#
+// ORC → ServiceRequest
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-orc-to-servicerequest.html
+// --------------------------------------------------------------------------------------------#
+public isolated function orcToServiceRequest(Orc orc) returns international401:ServiceRequest {
+    international401:ServiceRequest serviceRequest = {
+        intent: "order",
+        status: "unknown",
+        subject: {}
+    };
+
+    r4:Identifier[] identifiers = [];
+    r4:Identifier id1 = eiToIdentifier(<hl7v23:EI>orc.orc2);
+    if id1 != {} {
+        id1.'type = {coding: [{code: "PLAC", system: "http://terminology.hl7.org/CodeSystem/v2-0203"}]};
+        identifiers.push(id1);
+    }
+    r4:Identifier id2 = eiToIdentifier(orc.orc3);
+    if id2 != {} {
+        id2.'type = {coding: [{code: "FILL", system: "http://terminology.hl7.org/CodeSystem/v2-0203"}]};
+        identifiers.push(id2);
+    }
+    serviceRequest.identifier = (identifiers.length() > 0) ? identifiers : ();
+
+    r4:Reference requester = xcnToReference(orc.orc12[0]);
+    if requester != {} {
+        serviceRequest.requester = requester;
+    }
+
+    r4:CodeableConcept? reasonCode = ceToCodeableConcept(orc.orc16);
+    if reasonCode is r4:CodeableConcept && reasonCode != {} {
+        serviceRequest.reasonCode = [reasonCode];
+    }
+
+    serviceRequest.authoredOn = tsToDateTime(orc.orc9);
+    serviceRequest.occurrenceDateTime = tsToDateTime(orc.orc15);
+
+    return serviceRequest;
+};
+
+// --------------------------------------------------------------------------------------------#
+// PR1 → Procedure
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-pr1-to-procedure.html
+// --------------------------------------------------------------------------------------------#
+public isolated function pr1ToProcedure(Pr1 pr1) returns international401:Procedure {
+    international401:Procedure procedure = {
+        subject: {},
+        status: "unknown"
+    };
+
+    r4:CodeableConcept code = ceToCodeableConcept(pr1.pr13);
+    if code != {} {
+        if pr1.pr14 != "" {
+            code.text = pr1.pr14;
+        }
+        procedure.code = code;
+    }
+
+    procedure.performedDateTime = (pr1.pr15.ts1 != "") ? hl7DateToFhir(pr1.pr15.ts1) : ();
+
+    if pr1.pr16 != "" {
+        procedure.category = {
+            coding: [{code: pr1.pr16}]
+        };
+    }
+
+    international401:ProcedurePerformer[] performers = [];
+    foreach hl7v23:XCN item in pr1.pr18 {
+        r4:Reference ref = xcnToReferenceWithName(item, "Practitioner");
+        if ref != {} {
+            performers.push({
+                actor: ref,
+                'function: {coding: [{code: "88189002", system: "http://snomed.info/sct", display: "Anesthesiologist"}]}
+            });
+        }
+    }
+    foreach hl7v23:XCN item in pr1.pr111 {
+        r4:Reference ref = xcnToReferenceWithName(item, "Practitioner");
+        if ref != {} {
+            performers.push({
+                actor: ref,
+                'function: {coding: [{code: "304292004", system: "http://snomed.info/sct", display: "Surgeon"}]}
+            });
+        }
+    }
+    foreach hl7v23:XCN item in pr1.pr112 {
+        r4:Reference ref = xcnToReferenceWithName(item, "Practitioner");
+        if ref != {} {
+            performers.push({actor: ref});
+        }
+    }
+    procedure.performer = (performers.length() > 0) ? performers : ();
+
+    r4:CodeableConcept reasonCode = ceToCodeableConcept(pr1.pr115);
+    if reasonCode != {} {
+        procedure.reasonCode = [reasonCode];
+    }
+
+    return procedure;
+};
+
+// --------------------------------------------------------------------------------------------#
+// RXA → Immunization
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-rxa-to-immunization.html
+// --------------------------------------------------------------------------------------------#
+public isolated function rxaToImmunization(Rxa rxa) returns international401:Immunization {
+    international401:Immunization immunization = {
+        occurrenceDateTime: "",
+        occurrenceString: "",
+        patient: {},
+        status: "completed",
+        vaccineCode: {}
+    };
+
+    immunization.occurrenceDateTime = (rxa.rxa3.ts1 != "") ? hl7DateToFhir(rxa.rxa3.ts1) : ();
+
+    r4:CodeableConcept vaccineCode = ceToCodeableConcept(rxa.rxa5);
+    if vaccineCode != {} {
+        immunization.vaccineCode = vaccineCode;
+    }
+
+    if rxa.rxa6 != "" {
+        decimal|error doseVal = decimal:fromString(rxa.rxa6);
+        if doseVal is decimal {
+            r4:CodeableConcept doseUnits = ceToCodeableConcept(rxa.rxa7);
+            immunization.doseQuantity = {
+                value: doseVal,
+                code: doseUnits.coding != () ? doseUnits.coding.toString() : (),
+                unit: doseUnits.coding != () ? doseUnits.coding.toString() : ()
+            };
+        }
+    }
+
+    r4:Reference performer = xcnToReferenceWithName(rxa.rxa10, "Practitioner");
+    if performer != {} {
+        immunization.performer = [{
+            actor: performer,
+            'function: {coding: [{code: "AP", system: "http://terminology.hl7.org/CodeSystem/v2-0443", display: "Administering Provider"}]}
+        }];
+    }
+
+    if rxa.rxa15.length() > 0 && rxa.rxa15[0] != "" {
+        immunization.lotNumber = rxa.rxa15[0];
+    }
+
+    if rxa.rxa16.length() > 0 && rxa.rxa16[0].ts1 != "" {
+        immunization.expirationDate = hl7DateToFhir(rxa.rxa16[0].ts1);
+    }
+
+    if rxa.rxa17.length() > 0 {
+        r4:CodeableConcept mfr = ceToCodeableConcept(rxa.rxa17[0]);
+        if mfr != {} {
+            immunization.manufacturer = {display: mfr.coding.toString()};
+        }
+    }
+
+    if rxa.rxa18.length() > 0 {
+        r4:CodeableConcept refusalReason = ceToCodeableConcept(rxa.rxa18[0]);
+        if refusalReason != {} {
+            immunization.statusReason = refusalReason;
+        }
+    }
+
+    if rxa.rxa19.length() > 0 {
+        r4:CodeableConcept[] reasonCodes = [];
+        foreach hl7v23:CE item in rxa.rxa19 {
+            r4:CodeableConcept rc = ceToCodeableConcept(item);
+            if rc != {} {
+                reasonCodes.push(rc);
+            }
+        }
+        immunization.reasonCode = (reasonCodes.length() > 0) ? reasonCodes : ();
+    }
+
+    match rxa.rxa20 {
+        "CP" => { immunization.status = "completed"; }
+        "RE" => { immunization.status = "not-done"; }
+        "PA" => { immunization.status = "completed"; }
+        "NA" => { immunization.status = "not-done"; }
+        _ => { immunization.status = "completed"; }
+    }
+
+    immunization.recorded = tsToDateTime(rxa.rxa22);
+
+    return immunization;
+};
+
+// --------------------------------------------------------------------------------------------#
+// RXO → MedicationRequest
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-rxo-to-medicationrequest.html
+// --------------------------------------------------------------------------------------------#
+public isolated function rxoToMedicationRequest(Rxo rxo) returns international401:MedicationRequest {
+    international401:MedicationRequest medicationRequest = {
+        intent: "original-order",
+        status: "unknown",
+        subject: {},
+        medicationCodeableConcept: ceToCodeableConcept(rxo.rxo1)
+    };
+
+    r4:Reference requester = xcnToReferenceWithName(rxo.rxo14, "Practitioner");
+    if requester != {} {
+        medicationRequest.requester = requester;
+    }
+
+    r4:Dosage dosage = {};
+    if rxo.rxo2 != "" || rxo.rxo3 != "" {
+        decimal? lowVal = ();
+        decimal? highVal = ();
+        if rxo.rxo2 != "" {
+            decimal|error lv = decimal:fromString(rxo.rxo2);
+            if lv is decimal {
+                lowVal = lv;
+            }
+        }
+        if rxo.rxo3 != "" {
+            decimal|error hv = decimal:fromString(rxo.rxo3);
+            if hv is decimal {
+                highVal = hv;
+            }
+        }
+        r4:CodeableConcept units = ceToCodeableConcept(rxo.rxo4);
+        string? unitCode = ();
+        string? unitStr = ();
+        if units.coding != () {
+            r4:Coding[]? codings = units.coding;
+            if codings is r4:Coding[] && codings.length() > 0 {
+                unitCode = codings[0].code;
+                unitStr = codings[0].display;
+            }
+        }
+        if lowVal != () || highVal != () {
+            dosage.doseAndRate = [{
+                doseRange: {
+                    low: lowVal != () ? {value: lowVal, code: unitCode, unit: unitStr} : {},
+                    high: highVal != () ? {value: highVal, code: unitCode, unit: unitStr} : {}
+                }
+            }];
+        }
+    }
+    if dosage != {} {
+        medicationRequest.dosageInstruction = [dosage];
+    }
+
+    if rxo.rxo9 != "" {
+        medicationRequest.substitution = {
+            allowedCodeableConcept: {coding: [{code: rxo.rxo9}]}
+        };
+    }
+
+    if rxo.rxo11 != "" || rxo.rxo13 != "" {
+        international401:MedicationRequestDispenseRequest dispenseRequest = {};
+        if rxo.rxo11 != "" {
+            decimal|error qty = decimal:fromString(rxo.rxo11);
+            if qty is decimal {
+                dispenseRequest.quantity = {value: qty};
+            }
+        }
+        if rxo.rxo13 != "" {
+            decimal|error refills = decimal:fromString(rxo.rxo13);
+            if refills is decimal {
+                dispenseRequest.numberOfRepeatsAllowed = <int>refills;
+            }
+        }
+        if dispenseRequest != {} {
+            medicationRequest.dispenseRequest = dispenseRequest;
+        }
+    }
+
+    return medicationRequest;
+};
+
+// --------------------------------------------------------------------------------------------#
+// RXR → Immunization (adds route/site to immunization)
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-rxr-to-immunization.html
+// --------------------------------------------------------------------------------------------#
+public isolated function rxrToImmunization(Rxr rxr) returns international401:Immunization {
+    international401:Immunization immunization = {
+        occurrenceDateTime: "",
+        occurrenceString: "",
+        patient: {},
+        status: "completed",
+        vaccineCode: {}
+    };
+    r4:CodeableConcept route = ceToCodeableConcept(rxr.rxr1);
+    if route != {} {
+        immunization.route = route;
+    }
+    r4:CodeableConcept site = ceToCodeableConcept(rxr.rxr2);
+    if site != {} {
+        immunization.site = site;
+    }
+    return immunization;
+};
+
+// --------------------------------------------------------------------------------------------#
+// RXR → MedicationRequest (adds route/site/method to dosageInstruction)
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-rxr-to-medicationrequest.html
+// --------------------------------------------------------------------------------------------#
+public isolated function rxrToMedicationRequest(Rxr rxr) returns international401:MedicationRequest {
+    international401:MedicationRequest medicationRequest = {
+        intent: "order",
+        status: "unknown",
+        subject: {},
+        medicationCodeableConcept: {}
+    };
+    r4:Dosage dosage = {};
+    r4:CodeableConcept route = ceToCodeableConcept(rxr.rxr1);
+    if route != {} {
+        dosage.route = route;
+    }
+    r4:CodeableConcept site = ceToCodeableConcept(rxr.rxr2);
+    if site != {} {
+        dosage.site = site;
+    }
+    r4:CodeableConcept method = ceToCodeableConcept(rxr.rxr4);
+    if method != {} {
+        dosage.method = method;
+    }
+    if dosage != {} {
+        medicationRequest.dosageInstruction = [dosage];
+    }
+    return medicationRequest;
+};
+
+// --------------------------------------------------------------------------------------------#
+// SCH → Appointment
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-sch-to-appointment.html
+// --------------------------------------------------------------------------------------------#
+public isolated function schToAppointment(Sch sch) returns international401:Appointment {
+    international401:AppointmentParticipant defaultParticipant = {
+        status: "needs-action"
+    };
+    international401:Appointment appointment = {
+        status: "proposed",
+        participant: [defaultParticipant]
+    };
+
+    r4:Identifier[] identifiers = [];
+    r4:Identifier id1 = eiToIdentifier(sch.sch1);
+    if id1 != {} {
+        id1.'type = {coding: [{code: "PLAC", system: "http://terminology.hl7.org/CodeSystem/v2-0203"}]};
+        identifiers.push(id1);
+    }
+    r4:Identifier id2 = eiToIdentifier(sch.sch2);
+    if id2 != {} {
+        id2.'type = {coding: [{code: "FILL", system: "http://terminology.hl7.org/CodeSystem/v2-0203"}]};
+        identifiers.push(id2);
+    }
+    appointment.identifier = (identifiers.length() > 0) ? identifiers : ();
+
+    r4:CodeableConcept apptReason = ceToCodeableConcept(sch.sch7);
+    if apptReason != {} {
+        appointment.reasonCode = [apptReason];
+    }
+
+    r4:CodeableConcept apptType = ceToCodeableConcept(sch.sch8);
+    if apptType != {} {
+        appointment.appointmentType = apptType;
+    }
+
+    if sch.sch9 != "" {
+        decimal|error duration = decimal:fromString(sch.sch9);
+        if duration is decimal {
+            appointment.minutesDuration = <int>duration;
+        }
+    }
+
+    international401:AppointmentParticipant[] participants = [];
+    r4:Reference placer = xcnToReferenceWithName(sch.sch12, "Practitioner");
+    if placer != {} {
+        participants.push({
+            actor: placer,
+            'type: [{coding: [{code: "PART", system: "http://terminology.hl7.org/CodeSystem/v3-ParticipationType"}]}],
+            status: "accepted"
+        });
+    }
+    r4:Reference filler = xcnToReferenceWithName(sch.sch16, "Practitioner");
+    if filler != {} {
+        participants.push({
+            actor: filler,
+            'type: [{coding: [{code: "PART", system: "http://terminology.hl7.org/CodeSystem/v3-ParticipationType"}]}],
+            status: "accepted"
+        });
+    }
+    r4:Reference enteredBy = xcnToReferenceWithName(sch.sch20, "Practitioner");
+    if enteredBy != {} {
+        participants.push({
+            actor: enteredBy,
+            'type: [{coding: [{code: "ENT", system: "http://terminology.hl7.org/CodeSystem/v3-ParticipationType"}]}],
+            status: "accepted"
+        });
+    }
+    appointment.participant = (participants.length() > 0) ? participants : [defaultParticipant];
+
+    if sch.sch25.ce1 != "" {
+        match sch.sch25.ce1 {
+            "Pending" => { appointment.status = "pending"; }
+            "Complete" => { appointment.status = "fulfilled"; }
+            "Cancelled" => { appointment.status = "cancelled"; }
+            "Discontinued" => { appointment.status = "cancelled"; }
+            _ => { appointment.status = "proposed"; }
+        }
+    }
+
+    return appointment;
+};
+
+// --------------------------------------------------------------------------------------------#
+// TXA → DocumentReference
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-txa-to-documentreference.html
+// --------------------------------------------------------------------------------------------#
+public isolated function txaToDocumentReference(Txa txa) returns international401:DocumentReference {
+    international401:DocumentReference documentReference = {
+        status: "current",
+        content: [{attachment: {}}]
+    };
+
+    if txa.txa2 != "" {
+        documentReference.'type = {coding: [{code: txa.txa2}]};
+    }
+
+    if txa.txa3 != "" {
+        documentReference.content = [{
+            attachment: {
+                contentType: txa.txa3
+            }
+        }];
+    }
+
+    documentReference.date = (txa.txa6.ts1 != "") ? tsToInstant(txa.txa6) : ();
+
+    r4:Reference[] authors = [];
+    r4:Reference author = xcnToReferenceWithName(txa.txa9, "Practitioner");
+    if author != {} {
+        authors.push(author);
+    }
+    documentReference.author = (authors.length() > 0) ? authors : ();
+
+    if txa.txa10.length() > 0 {
+        r4:Reference auth = xcnToReferenceWithName(txa.txa10[0], "Practitioner");
+        if auth != {} {
+            documentReference.authenticator = auth;
+        }
+    }
+
+    r4:Identifier masterId = eiToIdentifier(txa.txa12);
+    if masterId != {} {
+        documentReference.masterIdentifier = masterId;
+    }
+
+    if txa.txa16 != "" {
+        documentReference.identifier = [{value: txa.txa16}];
+    }
+
+    if txa.txa17 != "" {
+        match txa.txa17 {
+            "AU" => { documentReference.docStatus = "final"; }
+            "DI" => { documentReference.docStatus = "preliminary"; }
+            "DO" => { documentReference.docStatus = "preliminary"; }
+            "IN" => { documentReference.docStatus = "preliminary"; }
+            "IP" => { documentReference.docStatus = "preliminary"; }
+            "LA" => { documentReference.docStatus = "amended"; }
+            "OB" => { documentReference.docStatus = "entered-in-error"; }
+            "PA" => { documentReference.docStatus = "preliminary"; }
+            "PR" => { documentReference.docStatus = "preliminary"; }
+            "PY" => { documentReference.docStatus = "amended"; }
+            "UN" => { documentReference.docStatus = "preliminary"; }
+            _ => {}
+        }
+    }
+
+    if txa.txa19 != "" {
+        match txa.txa19 {
+            "AV" => { documentReference.status = "current"; }
+            "CA" => { documentReference.status = "entered-in-error"; }
+            "OB" => { documentReference.status = "superseded"; }
+            "UN" => { documentReference.status = "current"; }
+            _ => {}
+        }
+    }
+
+    if txa.txa21 != "" {
+        documentReference.description = txa.txa21;
+    }
+
+    return documentReference;
+};
+
+// --------------------------------------------------------------------------------------------#
+// ROL → RelatedPerson
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-rol-to-relatedperson.html
+// --------------------------------------------------------------------------------------------#
+public isolated function rolToRelatedPerson(Rol rol) returns international401:RelatedPerson {
+    international401:RelatedPerson relatedPerson = {
+        patient: {}
+    };
+
+    r4:Identifier roleId = eiToIdentifier(rol.rol1);
+    if roleId != {} {
+        relatedPerson.identifier = [roleId];
+    }
+
+    r4:CodeableConcept relationship = ceToCodeableConcept(rol.rol3);
+    if relationship != {} {
+        relatedPerson.relationship = [relationship];
+    }
+
+    r4:HumanName personName = xcnToHumanName(rol.rol4);
+    if personName != {} {
+        relatedPerson.name = [personName];
+    }
+
+    r4:Period period = {
+        'start: (rol.rol5.ts1 != "") ? hl7DateToFhir(rol.rol5.ts1) : (),
+        end: (rol.rol6.ts1 != "") ? hl7DateToFhir(rol.rol6.ts1) : ()
+    };
+    if period != {} {
+        relatedPerson.period = period;
+    }
+
+    return relatedPerson;
+};
+
+// --------------------------------------------------------------------------------------------#
+// MSA → MessageHeader (response)
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-msa-to-messageheader.html
+// --------------------------------------------------------------------------------------------#
+public isolated function msaToMessageHeader(Msa msa) returns international401:MessageHeader {
+    international401:MessageHeaderResponseCode responseCode = "ok";
+    match msa.msa1 {
+        "AA" => { responseCode = "ok"; }
+        "AE" => { responseCode = "fatal-error"; }
+        "AR" => { responseCode = "fatal-error"; }
+        "CA" => { responseCode = "ok"; }
+        "CE" => { responseCode = "transient-error"; }
+        "CR" => { responseCode = "transient-error"; }
+        _ => { responseCode = "ok"; }
+    }
+    international401:MessageHeader messageHeader = {
+        'source: {endpoint: ""},
+        eventUri: "",
+        response: {
+            identifier: msa.msa2,
+            code: responseCode
+        }
+    };
+    return messageHeader;
+};
+
+// --------------------------------------------------------------------------------------------#
+// MRG → Account
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-mrg-to-account.html
+// --------------------------------------------------------------------------------------------#
+public isolated function mrgToAccount(Mrg mrg) returns international401:Account {
+    international401:Account account = {
+        status: "unknown"
+    };
+    r4:Identifier id = cxToIdentifier(mrg.mrg3);
+    if id != {} {
+        account.identifier = [id];
+    }
+    return account;
+};
+
+// --------------------------------------------------------------------------------------------#
+// IN1 → Coverage
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-in1-to-coverage.html
+// --------------------------------------------------------------------------------------------#
+public isolated function in1ToCoverage(In1 in1) returns international401:Coverage {
+    international401:Coverage coverage = {
+        status: "active",
+        beneficiary: {},
+        payor: [{}]
+    };
+
+    r4:Identifier planId = ceToCodeableConcept(in1.in12) != {} ? {value: in1.in12.ce1} : {};
+    if planId != {} {
+        coverage.identifier = [planId];
+    }
+
+    r4:Reference[] payors = [];
+    foreach hl7v23:XON item in in1.in14 {
+        if item.xon1 != "" {
+            payors.push({display: item.xon1});
+        }
+    }
+    coverage.payor = (payors.length() > 0) ? payors : [{}];
+
+    if in1.in112 != "" || in1.in113 != "" {
+        coverage.period = {
+            'start: (in1.in112 != "") ? in1.in112 : (),
+            end: (in1.in113 != "") ? in1.in113 : ()
+        };
+    }
+
+    if in1.in115 != "" {
+        coverage.'type = {coding: [{code: in1.in115}]};
+    }
+
+    if in1.in117 != "" {
+        coverage.relationship = {coding: [{code: in1.in117}]};
+    }
+
+    return coverage;
+};
+
+// --------------------------------------------------------------------------------------------#
+// IN3 → CareTeam
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-in3-to-careteam.html
+// --------------------------------------------------------------------------------------------#
+public isolated function in3ToCareTeam(In3 in3) returns international401:CareTeam {
+    international401:CareTeam careTeam = {};
+    if in3.in321 != "" {
+        careTeam.participant = [{
+            role: [{
+                coding: [{
+                    code: "116154003",
+                    system: "http://snomed.info/sct",
+                    display: "Case Manager"
+                }],
+                text: in3.in321
+            }]
+        }];
+    }
+    return careTeam;
+};
+
+// --------------------------------------------------------------------------------------------#
+// PV1 → Coverage
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-pv1-to-coverage.html
+// --------------------------------------------------------------------------------------------#
+public isolated function pv1ToCoverage(Pv1 pv1) returns international401:Coverage {
+    international401:Coverage coverage = {
+        status: "active",
+        beneficiary: {},
+        payor: [{}]
+    };
+    if pv1.pv120.length() > 0 && pv1.pv120[0].fc1 != "" {
+        coverage.'type = {coding: [{code: pv1.pv120[0].fc1}]};
+    }
+    return coverage;
+};
+
+// --------------------------------------------------------------------------------------------#
+// AIG → Appointment (adds resource participant)
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-aig-to-appointment.html
+// --------------------------------------------------------------------------------------------#
+public isolated function aigToAppointment(Aig aig) returns international401:Appointment {
+    international401:AppointmentParticipant participant = {
+        status: "needs-action"
+    };
+
+    r4:CodeableConcept resourceId = ceToCodeableConcept(aig.aig3);
+    if resourceId != {} {
+        participant.actor = {display: resourceId.coding.toString()};
+    }
+
+    r4:CodeableConcept resourceType = ceToCodeableConcept(aig.aig4);
+    if resourceType != {} {
+        participant.'type = [resourceType];
+    }
+
+    r4:Period period = {};
+    if aig.aig8.ts1 != "" {
+        period.'start = hl7DateToFhir(aig.aig8.ts1);
+    }
+    if period != {} {
+        participant.period = period;
+    }
+
+    return {
+        status: "proposed",
+        participant: [participant]
+    };
+};
+
+// --------------------------------------------------------------------------------------------#
+// AIL → Appointment (adds location participant)
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-ail-to-appointment.html
+// --------------------------------------------------------------------------------------------#
+public isolated function ailToAppointment(Ail ail) returns international401:Appointment {
+    international401:AppointmentParticipant participant = {
+        status: "needs-action"
+    };
+
+    if ail.ail3.pl1 != "" {
+        participant.actor = {display: ail.ail3.pl1};
+    }
+
+    r4:Period period = {};
+    if ail.ail6.ts1 != "" {
+        period.'start = hl7DateToFhir(ail.ail6.ts1);
+    }
+    if period != {} {
+        participant.period = period;
+    }
+
+    return {
+        status: "proposed",
+        participant: [participant]
+    };
+};
+
+// --------------------------------------------------------------------------------------------#
+// AIP → Appointment (adds personnel participant)
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-aip-to-appointment.html
+// --------------------------------------------------------------------------------------------#
+public isolated function aipToAppointment(Aip aip) returns international401:Appointment {
+    international401:AppointmentParticipant participant = {
+        status: "needs-action"
+    };
+
+    r4:Reference actor = xcnToReferenceWithName(aip.aip3, "Practitioner");
+    if actor != {} {
+        participant.actor = actor;
+    }
+
+    r4:CodeableConcept resourceType = ceToCodeableConcept(aip.aip4);
+    if resourceType != {} {
+        participant.'type = [resourceType];
+    }
+
+    r4:Period period = {};
+    if aip.aip6.ts1 != "" {
+        period.'start = hl7DateToFhir(aip.aip6.ts1);
+    }
+    if period != {} {
+        participant.period = period;
+    }
+
+    if aip.aip12.ce1 != "" {
+        match aip.aip12.ce1 {
+            "Accepted" => { participant.status = "accepted"; }
+            "Declined" => { participant.status = "declined"; }
+            "Tentative" => { participant.status = "tentative"; }
+            _ => { participant.status = "needs-action"; }
+        }
+    }
+
+    return {
+        status: "proposed",
+        participant: [participant]
+    };
+};
+
+// --------------------------------------------------------------------------------------------#
+// AIS → Appointment (adds service type)
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-ais-to-appointment.html
+// --------------------------------------------------------------------------------------------#
+public isolated function aisToAppointment(Ais ais) returns international401:Appointment {
+    international401:AppointmentParticipant defaultParticipant = {
+        status: "needs-action"
+    };
+    international401:Appointment appointment = {
+        status: "proposed",
+        participant: [defaultParticipant]
+    };
+
+    r4:CodeableConcept serviceType = ceToCodeableConcept(ais.ais3);
+    if serviceType != {} {
+        appointment.serviceType = [serviceType];
+    }
+
+    if ais.ais10.ce1 != "" {
+        match ais.ais10.ce1 {
+            "Pending" => { appointment.status = "pending"; }
+            "Complete" => { appointment.status = "fulfilled"; }
+            "Cancelled" => { appointment.status = "cancelled"; }
+            "Discontinued" => { appointment.status = "cancelled"; }
+            _ => { appointment.status = "proposed"; }
+        }
+    }
+
+    return appointment;
 };

--- a/utils/v23tofhirr4/mappings.bal
+++ b/utils/v23tofhirr4/mappings.bal
@@ -246,7 +246,7 @@ public isolated function mshToMessageHeader(Msh msh) returns international401:Me
     international401:MessageHeader messageHeader = {
         'source: hdToMessageHeaderSource(msh.msh3),
         destination: [hdToMessageHeaderDestination(msh.msh5)],
-        eventCoding: (msh.msh9 is hl7v23:CM_MSG) ? msgToCoding(<hl7v23:CM_MSG>msh.msh9) : {},
+        eventCoding: msgToCoding(msh.msh9),
         language: ceToCode(<hl7v23:CE>msh.msh19),
         eventUri: ""
     };
@@ -257,18 +257,16 @@ public isolated function mshToMessageHeader(Msh msh) returns international401:Me
 public isolated function al1ToAllerygyIntolerance(Al1 al1) returns international401:AllergyIntolerance {
 
     international401:AllergyIntoleranceReaction[] allergyIntoleranceReactions = [];
-    if al1.al15 is hl7v23:ST && al1 is hl7v23:AL1 {
-        allergyIntoleranceReactions = [
-            {
-                manifestation: (al1.al15 != "") ? [
-                        {
-                            text: <hl7v23:ST>al1.al15
-                        }
-                    ] : [],
-                onset: (al1.al16 != "") ? al1.al16 : ()
-            }
-        ];
-    }
+    allergyIntoleranceReactions = [
+        {
+            manifestation: (al1.al15 != "") ? [
+                    {
+                        text: al1.al15
+                    }
+                ] : [],
+            onset: (al1.al16 != "") ? al1.al16 : ()
+        }
+    ];
     r4:CodeableConcept allergyCode = ceToCodeableConcept(<hl7v23:CE>al1.al13);
     international401:AllergyIntolerance allergyIntolerance = {
         clinicalStatus: {
@@ -284,15 +282,11 @@ public isolated function al1ToAllerygyIntolerance(Al1 al1) returns international
         patient: {}
     };
 
-    if al1.al14 is hl7v23:IS {
-        if al1.al14 == "SV" {
-            allergyIntolerance.criticality = international401:CODE_CRITICALITY_HIGH;
-        }
+    if al1.al14 == "SV" {
+        allergyIntolerance.criticality = international401:CODE_CRITICALITY_HIGH;
     }
 
-    if al1.al12 is hl7v23:IS {
-        allergyIntolerance.'type = isToAllergyIntoleranceType(<hl7v23:IS>al1.al12);
-    }
+    allergyIntolerance.'type = isToAllergyIntoleranceType(al1.al12);
 
     return allergyIntolerance;
 }
@@ -306,13 +300,11 @@ public isolated function evnToProvenance(Evn evn) returns international401:Prove
     ];
 
     international401:ProvenanceAgent[] agent = [];
-    if evn.evn5 is hl7v23:XCN {
-        r4:Reference xcnToReferenceResult = xcnToReferenceWithType(<hl7v23:XCN>evn.evn5, "Practitioner");
-        if xcnToReferenceResult != {} {
-            agent.push({
-                who: xcnToReferenceResult
-            });
-        }
+    r4:Reference xcnToReferenceResult = xcnToReferenceWithType(evn.evn5, "Practitioner");
+    if xcnToReferenceResult != {} {
+        agent.push({
+            who: xcnToReferenceResult
+        });
     }
     r4:instant recorded = "";
     r4:dateTime occurredDateTime = "";
@@ -327,26 +319,22 @@ public isolated function evnToProvenance(Evn evn) returns international401:Prove
         target: []
     };
 
-    if evn is hl7v23:EVN {
-        if evn.evn4 != "" && evn.evn4 != "U" {
-            provenance.reason = [
-                {
-                    coding: [
-                        {
-                            code: evn.evn4
-                        }
-                    ]
-                }
-            ];
-        }
+    if evn.evn4 != "" && evn.evn4 != "U" {
+        provenance.reason = [
+            {
+                coding: [
+                    {
+                        code: evn.evn4
+                    }
+                ]
+            }
+        ];
     }
 
-    if evn is hl7v23:EVN {
-        if evn.evn2.ts1 != "" {
-            provenance.recorded = evn.evn2.ts1;
-        }
-        provenance.occurredDateTime = (evn.evn6.ts1 != "") ? hl7DateToFhir(evn.evn6.ts1) : ();
+    if evn.evn2.ts1 != "" {
+        provenance.recorded = evn.evn2.ts1;
     }
+    provenance.occurredDateTime = (evn.evn6.ts1 != "") ? hl7DateToFhir(evn.evn6.ts1) : ();
 
     return provenance;
 };
@@ -357,9 +345,7 @@ public isolated function nk1ToPatient(Nk1 nk1) returns international401:Patient 
 
 public isolated function pd1ToPatient(Pd1 pd1) returns international401:Patient {
     r4:Extension[]? extension = [];
-    if pd1 is hl7v23:PD1 {
-        extension = pd1ToExtension(pd1.pd16);
-    }
+    extension = pd1ToExtension(pd1.pd16);
     return {
         generalPractitioner: pd1ToGeneralPractitioner(pd1.pd13, pd1.pd14),
         extension: extension
@@ -380,21 +366,15 @@ public isolated function pidToPatient(Pid pid) returns international401:Patient 
         deceasedBoolean: (pid.pid30 != "") ? pidToPatientDeathIndicator(pid.pid30) : ()
     };
 
-    if pid is hl7v23:PID {
-        patient.name = pidToPatientName(pid.pid5, pid.pid9);
-        patient.birthDate = (pid.pid7.ts1 != "") ? hl7DateToFhir(pid.pid7.ts1) : ();
-        patient.deceasedDateTime = (pid.pid29.ts1 != "") ? hl7DateToFhir(pid.pid29.ts1) : ();
-        patient.gender = pidToAdministrativeSex(pid.pid8);
-    }
+    patient.name = pidToPatientName(pid.pid5, pid.pid9);
+    patient.birthDate = (pid.pid7.ts1 != "") ? hl7DateToFhir(pid.pid7.ts1) : ();
+    patient.deceasedDateTime = (pid.pid29.ts1 != "") ? hl7DateToFhir(pid.pid29.ts1) : ();
+    patient.gender = pidToAdministrativeSex(pid.pid8);
     return patient;
 };
 
 public isolated function pv1ToPatient(Pv1 pv1) returns international401:Patient {
-    string extension = "";
-
-    if pv1 is hl7v23:PV1 {
-        extension = pv1.pv116;
-    }
+    string extension = pv1.pv116;
     return {
         extension: (extension != "") ? pv1ToExtension(extension) : ()
     };
@@ -406,69 +386,62 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
         status: "in-progress"
     };
     international401:EncounterLocation[] encounterLocations = [];
-    if pv1 is hl7v23:PV1 {
-        international401:EncounterLocation encounterLoc1 = {
-            location: {
-                display: pv1.pv13.pl1 != "" ? pv1.pv13.pl1 : ()
-            },
-            status: getEncounterLocationStatus(pv1.pv13.pl5)
-        };
-        encounterLocations.push(encounterLoc1);
+    international401:EncounterLocation encounterLoc1 = {
+        location: {
+            display: pv1.pv13.pl1 != "" ? pv1.pv13.pl1 : ()
+        },
+        status: getEncounterLocationStatus(pv1.pv13.pl5)
+    };
+    encounterLocations.push(encounterLoc1);
 
-        international401:EncounterLocation encounterLoc2 = {
-            location: {
-                display: pv1.pv16.pl1 != "" ? pv1.pv16.pl1 : ()
-            },
-            status: getEncounterLocationStatus(pv1.pv16.pl5)
-        };
-        encounterLocations.push(encounterLoc2);
+    international401:EncounterLocation encounterLoc2 = {
+        location: {
+            display: pv1.pv16.pl1 != "" ? pv1.pv16.pl1 : ()
+        },
+        status: getEncounterLocationStatus(pv1.pv16.pl5)
+    };
+    encounterLocations.push(encounterLoc2);
 
-        international401:EncounterLocation encounterLoc3 = {
-            location: {
-                display: pv1.pv111.pl1 != "" ? pv1.pv111.pl1 : ()
-            },
-            status: getEncounterLocationStatus(pv1.pv111.pl5)
-        };
-        encounterLocations.push(encounterLoc3);
+    international401:EncounterLocation encounterLoc3 = {
+        location: {
+            display: pv1.pv111.pl1 != "" ? pv1.pv111.pl1 : ()
+        },
+        status: getEncounterLocationStatus(pv1.pv111.pl5)
+    };
+    encounterLocations.push(encounterLoc3);
 
-        international401:EncounterLocation encounterLoc4 = {
-            location: {
-                display: pv1.pv142.pl1 != "" ? pv1.pv142.pl1 : ()
-            },
-            status: getEncounterLocationStatus(pv1.pv142.pl5)
-        };
-        encounterLocations.push(encounterLoc4);
+    international401:EncounterLocation encounterLoc4 = {
+        location: {
+            display: pv1.pv142.pl1 != "" ? pv1.pv142.pl1 : ()
+        },
+        status: getEncounterLocationStatus(pv1.pv142.pl5)
+    };
+    encounterLocations.push(encounterLoc4);
 
-        international401:EncounterLocation encounterLoc5 = {
-            location: {
-                display: pv1.pv142.pl1 != "" ? pv1.pv142.pl1 : ()
-            },
-            status: getEncounterLocationStatus(pv1.pv142.pl5)
-        };
-        encounterLocations.push(encounterLoc5);
+    international401:EncounterLocation encounterLoc5 = {
+        location: {
+            display: pv1.pv142.pl1 != "" ? pv1.pv142.pl1 : ()
+        },
+        status: getEncounterLocationStatus(pv1.pv142.pl5)
+    };
+    encounterLocations.push(encounterLoc5);
 
-        international401:EncounterLocation encounterLoc6 = {
-            location: {
-                display: pv1.pv143.pl1 != "" ? pv1.pv143.pl1 : ()
-            },
-            status: getEncounterLocationStatus(pv1.pv143.pl5)
-        };
-        encounterLocations.push(encounterLoc6);
-    }
+    international401:EncounterLocation encounterLoc6 = {
+        location: {
+            display: pv1.pv143.pl1 != "" ? pv1.pv143.pl1 : ()
+        },
+        status: getEncounterLocationStatus(pv1.pv143.pl5)
+    };
+    encounterLocations.push(encounterLoc6);
 
     international401:EncounterParticipant[] participants = [];
 
     int i = 0;
     int len = 1; // in hl7v23 case
     while i < len {
-        string system = "";
-        string xcn1 = "";
-        string xcn10 = "";
-        if pv1 is hl7v23:PV1 {
-            system = pv1.pv17[i].xcn8;
-            xcn1 = pv1.pv17[i].xcn1;
-            xcn10 = pv1.pv17[i].xcn10;
-        }
+        string system = pv1.pv17[i].xcn8;
+        string xcn1 = pv1.pv17[i].xcn1;
+        string xcn10 = pv1.pv17[i].xcn10;
 
         international401:EncounterParticipant encounterParticipant =
             {
@@ -495,14 +468,9 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
     i = 0;
     int lenPv18 = 1; // in hl7v23 case
     while i < lenPv18 {
-        string system = "";
-        string xcn1 = "";
-        string xcn10 = "";
-        if pv1 is hl7v23:PV1 {
-            system = pv1.pv18[i].xcn8;
-            xcn1 = pv1.pv18[i].xcn1;
-            xcn10 = pv1.pv18[i].xcn10;
-        }
+        string system = pv1.pv18[i].xcn8;
+        string xcn1 = pv1.pv18[i].xcn1;
+        string xcn10 = pv1.pv18[i].xcn10;
         international401:EncounterParticipant encounterParticipant = {
             individual: (xcn1 != "") ? {
                     display: xcn1
@@ -527,10 +495,7 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
 
     i = 0;
     while i < pv1.pv19.length() {
-        string system = "";
-        if pv1 is hl7v23:PV1 {
-            system = pv1.pv19[i].xcn8;
-        }
+        string system = pv1.pv19[i].xcn8;
         international401:EncounterParticipant encounterParticipant = {
             individual: (pv1.pv19[i].xcn1 != "") ? {
                     display: pv1.pv19[i].xcn1
@@ -556,16 +521,10 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
     i = 0;
     int lenPv17 = 1; // in hl7v23 case
     while i < lenPv17 {
-        string system = "";
-        string code = "";
-        string xcn1 = "";
-        string xcn10 = "";
-        if pv1 is hl7v23:PV1 {
-            system = pv1.pv17[i].xcn8;
-            code = pv1.pv17[i].xcn10;
-            xcn1 = pv1.pv17[i].xcn1;
-            xcn10 = pv1.pv17[i].xcn10;
-        }
+        string system = pv1.pv17[i].xcn8;
+        string code = pv1.pv17[i].xcn10;
+        string xcn1 = pv1.pv17[i].xcn1;
+        string xcn10 = pv1.pv17[i].xcn10;
         international401:EncounterParticipant encounterParticipant = {
             individual: (xcn1 != "") ? {
                     display: xcn1
@@ -588,100 +547,83 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
         i = +1;
     }
 
-    if pv1 is hl7v23:PV1 {
-        // Define pv1.pv152 hl7v27:PV1, hl7v28:PV1
-        i = 0;
-        while i < pv1.pv152.length() {
-            international401:EncounterParticipant encounterParticipant = {
-                individual: (pv1.pv152[i].xcn1 != "") ? {
-                        display: pv1.pv152[i].xcn1
-                    } : (),
-                'type: (pv1.pv152[i].xcn8 != "") ? [
-                        {
-                            coding: [
-                                {
-                                    code: "PART",
-                                    system: pv1.pv152[i].xcn8,
-                                    display: "Participation"
-                                }
-                            ]
-                        }
-                    ] : ()
-            };
-            if encounterParticipant != {} {
-                participants.push(encounterParticipant);
+    // Define pv1.pv152 hl7v27:PV1, hl7v28:PV1
+    i = 0;
+    while i < pv1.pv152.length() {
+        international401:EncounterParticipant encounterParticipant = {
+            individual: (pv1.pv152[i].xcn1 != "") ? {
+                    display: pv1.pv152[i].xcn1
+                } : (),
+            'type: (pv1.pv152[i].xcn8 != "") ? [
+                    {
+                        coding: [
+                            {
+                                code: "PART",
+                                system: pv1.pv152[i].xcn8,
+                                display: "Participation"
+                            }
+                        ]
+                    }
+                ] : ()
+        };
+        if encounterParticipant != {} {
+            participants.push(encounterParticipant);
+        }
+        i = +1;
+    }
+
+    if pv1.pv12 != "" {
+        encounter.'class = {
+            display: pv1.pv12
+        };
+    }
+
+    if pv1.pv14 != "" {
+        encounter.'type = [
+            {
+                text: pv1.pv14
             }
-            i = +1;
-        }
+        ];
     }
 
-    if pv1 is hl7v23:PV1 {
-        if pv1.pv12 != "" {
-            encounter.'class = {
-                display: pv1.pv12
-            };
-        }
+    if pv1.pv113 != "" {
+        encounter.hospitalization.reAdmission = {
+            text: pv1.pv113
+        };
     }
 
-    if pv1 is hl7v23:PV1 {
-        if pv1.pv14 != "" {
-            encounter.'type = [
-                {
-                    text: pv1.pv14
-                }
-            ];
-        }
+    if pv1.pv114 != "" {
+        encounter.hospitalization.admitSource = {
+            text: pv1.pv114
+        };
     }
 
-    if pv1 is hl7v23:PV1 {
-        if pv1.pv113 != "" {
-            encounter.hospitalization.reAdmission = {
-                text: pv1.pv113
-            };
-        }
+    if pv1.pv136 != "" {
+        encounter.hospitalization.dischargeDisposition = {
+            text: pv1.pv136
+        };
     }
 
-    if pv1 is hl7v23:PV1 {
-        if pv1.pv114 != "" {
-            encounter.hospitalization.admitSource = {
-                text: pv1.pv114
-            };
-        }
-    }
-    if pv1 is hl7v23:PV1 {
-        if pv1.pv136 != "" {
-            encounter.hospitalization.dischargeDisposition = {
-                text: pv1.pv136
-            };
-        }
+    if pv1.pv137.cm_dld1 != "" {
+        encounter.hospitalization.destination = {
+            reference: pv1.pv137.cm_dld1
+        };
     }
 
-    if pv1 is hl7v23:PV1 {
-        if pv1.pv137.cm_dld1 != "" {
-            encounter.hospitalization.destination = {
-                reference: pv1.pv137.cm_dld1
-            };
-        }
+    if pv1.pv138 != "" {
+        encounter.hospitalization.dietPreference = [
+            {
+                text: pv1.pv138
+            }
+        ];
     }
 
-    if pv1 is hl7v23:PV1 {
-        if pv1.pv138 != "" {
-            encounter.hospitalization.dietPreference = [
-                {
-                    text: pv1.pv138
-                }
-            ];
-        }
-    }
-
-    if pv1 is hl7v23:PV1 {
-        if pv1.pv139 != "" {
-            encounter.hospitalization.specialCourtesy = [
-                {
-                    text: pv1.pv139
-                }
-            ];
-        }
+    if pv1.pv139 != "" {
+        encounter.hospitalization.specialCourtesy = [
+            {
+                text: pv1.pv139
+            }
+        ];
     }
 
     if pv1.pv15.cx1 != "" {
@@ -693,12 +635,10 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
         };
     }
 
-    if pv1 is hl7v23:PV1 {
-        if pv1.pv110 != "" {
-            encounter.serviceType = {
-                text: pv1.pv110
-            };
-        }
+    if pv1.pv110 != "" {
+        encounter.serviceType = {
+            text: pv1.pv110
+        };
     }
 
     r4:Identifier[] identifier = [];
@@ -732,22 +672,15 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
     }
     encounter.identifier = (identifier.length() > 0) ? identifier : ();
 
-    if pv1 is hl7v23:PV1 {
-        encounter.period.'start = (pv1.pv144.ts1 != "") ? pv1.pv144.ts1 : ();
-    }
-
-    if pv1 is hl7v23:PV1 {
-        encounter.period.end = (pv1.pv145.ts1 != "") ? pv1.pv145.ts1 : ();
-    }
+    encounter.period.'start = (pv1.pv144.ts1 != "") ? pv1.pv144.ts1 : ();
+    encounter.period.end = (pv1.pv145.ts1 != "") ? pv1.pv145.ts1 : ();
 
     if encounter.period == {} {
         encounter.period = ();
     }
 
-    if pv1 is hl7v23:PV1 {
-        if pv1.pv145.ts1 != "" {
-            encounter.status = "finished";
-        }
+    if pv1.pv145.ts1 != "" {
+        encounter.status = "finished";
     }
 
     encounter.location = (encounterLocations.length() > 0) ? encounterLocations : ();
@@ -757,10 +690,7 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
 };
 
 public isolated function pv2ToEncounter(Pv2 pv2) returns international401:Encounter {
-    string display = "";
-    if pv2 is hl7v23:PV2 {
-        display = pv2.pv21.pl1;
-    }
+    string display = pv2.pv21.pl1;
     international401:EncounterLocation[] location = [
         {
             location: {
@@ -772,18 +702,13 @@ public isolated function pv2ToEncounter(Pv2 pv2) returns international401:Encoun
     r4:Coding[] coding = [idToCoding(pv2.pv222)];
 
     international401:EncounterParticipant[] participant = []; // TODO: participant need to mapped correctly
-    if pv2.pv213 is hl7v23:XCN {
-        participant = [
-            {
-                id: (<hl7v23:XCN>pv2.pv213).xcn1
-            }
-        ];
-    }
+    participant = [
+        {
+            id: pv2.pv213.xcn1
+        }
+    ];
 
-    string priority = "";
-    if pv2 is hl7v23:PV2 {
-        priority = pv2.pv225;
-    }
+    string priority = pv2.pv225;
 
     international401:Encounter encounter = {
         location: location,
@@ -823,15 +748,13 @@ public isolated function dg1ToCondition(Dg1 dg1) returns international401:Condit
     international401:Condition condition = {
         subject: {}
     };
-    if dg1 is hl7v23:DG1 {
-        r4:CodeableConcept ceToCodeableConceptResult = ceToCodeableConcept(dg1.dg13);
-        if ceToCodeableConceptResult != {} {
-            ceToCodeableConceptResult.text = (dg1.dg14 != "") ? dg1.dg14 : ();
-            condition.code = ceToCodeableConceptResult;
-        }
-        condition.onsetDateTime = dg1.dg15.ts1 != "" ? hl7DateToFhir(dg1.dg15.ts1) : ();
-        condition.recordedDate = dg1.dg119.ts1 != "" ? hl7DateToFhir(dg1.dg119.ts1) : ();
+    r4:CodeableConcept ceToCodeableConceptResult = ceToCodeableConcept(dg1.dg13);
+    if ceToCodeableConceptResult != {} {
+        ceToCodeableConceptResult.text = (dg1.dg14 != "") ? dg1.dg14 : ();
+        condition.code = ceToCodeableConceptResult;
     }
+    condition.onsetDateTime = dg1.dg15.ts1 != "" ? hl7DateToFhir(dg1.dg15.ts1) : ();
+    condition.recordedDate = dg1.dg119.ts1 != "" ? hl7DateToFhir(dg1.dg119.ts1) : ();
     Xcn[] dg116 = dg1.dg116;
     foreach var item in dg116 {
         if item.xcn1 != "" {
@@ -850,22 +773,20 @@ public isolated function dg1ToEncounter(Dg1 dg1, string? conditionId) returns in
         'class: {},
         status: "finished"
     };
-    if dg1 is hl7v23:DG1 {
-        Is dg16 = dg1.dg16;
-        if conditionId is string {
-            international401:EncounterDiagnosis encounterDiagnosis = {
-                condition: {
-                    reference: string `Condition/${conditionId}`
-                }
-            };
-            if dg16 != "" {
-                encounterDiagnosis.use = {
-                    text: dg16
-                };
+    Is dg16 = dg1.dg16;
+    if conditionId is string {
+        international401:EncounterDiagnosis encounterDiagnosis = {
+            condition: {
+                reference: string `Condition/${conditionId}`
             }
-            encounter.diagnosis = [encounterDiagnosis];
-            encounter.id = generateFhirResourceId();
+        };
+        if dg16 != "" {
+            encounterDiagnosis.use = {
+                text: dg16
+            };
         }
+        encounter.diagnosis = [encounterDiagnosis];
+        encounter.id = generateFhirResourceId();
     }
     return encounter;
 }
@@ -882,13 +803,11 @@ public isolated function dg1ToEpisodeOfCare(Dg1 dg1, string? conditionId, string
             }
         };
         episodeOfCare.diagnosis = [episodeOfCareDiagnosis];
-        if dg1 is hl7v23:DG1 {
-            Is dg16 = dg1.dg16;
-            if dg16 != "" {
-                episodeOfCareDiagnosis.role = {
-                    text: dg16
-                };
-            }
+        Is dg16 = dg1.dg16;
+        if dg16 != "" {
+            episodeOfCareDiagnosis.role = {
+                text: dg16
+            };
         }
     }
     if patientId is string {
@@ -907,16 +826,14 @@ public isolated function obxToObservation(Obx obx) returns international401:Obse
         dataAbsentReason: idToCodeableConcept(obx.obx11),
         status: "preliminary"
     };
-    if obx is hl7v23:OBX {
-        r4:CodeableConcept code = ceToCodeableConcept(obx.obx3);
-        if code != {} {
-            observation.code = code;
-        }
-        observation.effectiveDateTime = (obx.obx14.ts1 != "") ? tsToDateTime(obx.obx14) : ();
-        r4:CodeableConcept method = ceToCodeableConcept(obx.obx17[0]);
-        if method != {} {
-            observation.method = method;
-        }
+    r4:CodeableConcept code = ceToCodeableConcept(obx.obx3);
+    if code != {} {
+        observation.code = code;
+    }
+    observation.effectiveDateTime = (obx.obx14.ts1 != "") ? tsToDateTime(obx.obx14) : ();
+    r4:CodeableConcept method = ceToCodeableConcept(obx.obx17[0]);
+    if method != {} {
+        observation.method = method;
     }
     return observation;
 };
@@ -928,16 +845,14 @@ public isolated function obrToDiagnosticReport(Obr obr) returns international401
         category: idToCodeableConceptArray(obr.obr24),
         status: idToDiagnosticReportStatus(obr.obr25)
     };
-    if obr is hl7v23:OBR {
-        r4:CodeableConcept ceToCodeableConceptResult = ceToCodeableConcept(obr.obr4);
-        if ceToCodeableConceptResult != {} {
-            diagnosticReport.code = ceToCodeableConceptResult;
-        }
-        diagnosticReport.effectiveDateTime = tsToDateTime(obr.obr7);
-        diagnosticReport.effectivePeriod.'start = tsToDateTime(obr.obr7);
-        diagnosticReport.effectivePeriod.end = tsToDateTime(obr.obr8);
-        diagnosticReport.issued = tsToInstant(obr.obr22);
+    r4:CodeableConcept ceToCodeableConceptResult = ceToCodeableConcept(obr.obr4);
+    if ceToCodeableConceptResult != {} {
+        diagnosticReport.code = ceToCodeableConceptResult;
     }
+    diagnosticReport.effectiveDateTime = tsToDateTime(obr.obr7);
+    diagnosticReport.effectivePeriod.'start = tsToDateTime(obr.obr7);
+    diagnosticReport.effectivePeriod.end = tsToDateTime(obr.obr8);
+    diagnosticReport.issued = tsToInstant(obr.obr22);
     r4:Identifier eiToIdentifierResult = eiToIdentifier(obr.obr2);
     if eiToIdentifierResult != {} {
         diagnosticReport.subject.identifier = eiToIdentifierResult;
@@ -960,14 +875,12 @@ public function obrToServiceRequest(Obr obr) returns international401:ServiceReq
     if xcnToReferenceResult != {} {
         serviceRequest.requester = xcnToReferenceResult;
     }
-    if obr is hl7v23:OBR {
-        r4:CodeableConcept ceToCodeableConceptResult = ceToCodeableConcept(obr.obr4);
-        if ceToCodeableConceptResult != {} {
-            serviceRequest.code = ceToCodeableConceptResult;
-        }
-        serviceRequest.occurrenceDateTime = tsToDateTime(obr.obr6);
-        serviceRequest.reasonCode = [ceToCodeableConcept(obr.obr31[0])];
+    r4:CodeableConcept ceToCodeableConceptResult = ceToCodeableConcept(obr.obr4);
+    if ceToCodeableConceptResult != {} {
+        serviceRequest.code = ceToCodeableConceptResult;
     }
+    serviceRequest.occurrenceDateTime = tsToDateTime(obr.obr6);
+    serviceRequest.reasonCode = [ceToCodeableConcept(obr.obr31[0])];
     return serviceRequest;
 };
 
@@ -1000,13 +913,11 @@ public function orcToDiagnosticReport(Orc orc) returns international401:Diagnost
     r4:uri url = "";
     r4:CodeableConcept valueCodeableConcept = {};
 
-    if orc is hl7v23:ORC {
-        r4:uri? ceToUriResult = ceToUri(orc.orc16);
-        if ceToUriResult is r4:uri {
-            url = ceToUriResult;
-        }
-        valueCodeableConcept = ceToCodeableConcept(orc.orc16);
+    r4:uri? ceToUriResult = ceToUri(orc.orc16);
+    if ceToUriResult is r4:uri {
+        url = ceToUriResult;
     }
+    valueCodeableConcept = ceToCodeableConcept(orc.orc16);
 
     // Extensions
     r4:Extension[] ext = [
@@ -1064,9 +975,7 @@ public isolated function orcToImmunization(Orc orc) returns international401:Imm
         status: "not-done",
         vaccineCode: {}
     };
-    if orc is hl7v23:ORC {
-        immunization.recorded = tsToDateTime(orc.orc9);
-    }
+    immunization.recorded = tsToDateTime(orc.orc9);
 
     return immunization;
 };

--- a/utils/v23tofhirr4/mappings.bal
+++ b/utils/v23tofhirr4/mappings.bal
@@ -584,17 +584,21 @@ public isolated function pd1ToPatient(Pd1 pd1) returns international401:Patient 
 // URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-pd1-to-observation.html
 // --------------------------------------------------------------------------------------------#
 public isolated function pd1ToLivingWillObservation(Pd1 pd1) returns international401:Observation {
-    return {
+    international401:Observation observation = {
         status: "final",
+        subject: {},
         code: {
             coding: [{
                 system: "http://loinc.org",
                 code: "45473-6",
                 display: "Advance directive - living will"
             }]
-        },
-        valueCodeableConcept: {coding: [{code: pd1.pd17}]}
+        }
     };
+    if pd1.pd17 != "" {
+        observation.valueCodeableConcept = {coding: [{code: pd1.pd17}]};
+    }
+    return observation;
 };
 
 public isolated function pidToPatient(Pid pid) returns international401:Patient {
@@ -661,23 +665,19 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
         },
         status: getEncounterLocationStatus(pv1.pv142.pl5)
     };
-    encounterLocations.push(encounterLoc4);
+    if pv1.pv142.pl1 != "" {
+        encounterLocations.push(encounterLoc4);
+    }
 
     international401:EncounterLocation encounterLoc5 = {
-        location: {
-            display: pv1.pv142.pl1 != "" ? pv1.pv142.pl1 : ()
-        },
-        status: getEncounterLocationStatus(pv1.pv142.pl5)
-    };
-    encounterLocations.push(encounterLoc5);
-
-    international401:EncounterLocation encounterLoc6 = {
         location: {
             display: pv1.pv143.pl1 != "" ? pv1.pv143.pl1 : ()
         },
         status: getEncounterLocationStatus(pv1.pv143.pl5)
     };
-    encounterLocations.push(encounterLoc6);
+    if pv1.pv143.pl1 != "" {
+        encounterLocations.push(encounterLoc5);
+    }
 
     international401:EncounterParticipant[] participants = [];
 
@@ -917,8 +917,8 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
     }
     encounter.identifier = (identifier.length() > 0) ? identifier : ();
 
-    encounter.period.'start = (pv1.pv144.ts1 != "") ? pv1.pv144.ts1 : ();
-    encounter.period.end = (pv1.pv145.ts1 != "") ? pv1.pv145.ts1 : ();
+    encounter.period.'start = (pv1.pv144.ts1 != "") ? hl7DateToFhir(pv1.pv144.ts1) : ();
+    encounter.period.end = (pv1.pv145.ts1 != "") ? hl7DateToFhir(pv1.pv145.ts1) : ();
 
     if encounter.period == {} {
         encounter.period = ();
@@ -2010,7 +2010,7 @@ public isolated function in1ToCoverage(In1 in1) returns international401:Coverag
         payor: [{}]
     };
 
-    r4:Identifier planId = ceToCodeableConcept(in1.in12) != {} ? {value: in1.in12.ce1} : {};
+    r4:Identifier planId = (in1.in12.ce1 != "") ? {value: in1.in12.ce1} : {};
     if planId != {} {
         coverage.identifier = [planId];
     }
@@ -2025,8 +2025,8 @@ public isolated function in1ToCoverage(In1 in1) returns international401:Coverag
 
     if in1.in112 != "" || in1.in113 != "" {
         coverage.period = {
-            'start: (in1.in112 != "") ? in1.in112 : (),
-            end: (in1.in113 != "") ? in1.in113 : ()
+            'start: (in1.in112 != "") ? hl7DateToFhir(in1.in112) : (),
+            end: (in1.in113 != "") ? hl7DateToFhir(in1.in113) : ()
         };
     }
 

--- a/utils/v23tofhirr4/mappings.bal
+++ b/utils/v23tofhirr4/mappings.bal
@@ -1890,7 +1890,30 @@ public isolated function txaToProvenance(Txa txa) returns international401:Prove
     return provenance;
 };
 
-// --------------------------------------------------------------------------------------------#
+// MSH[Provenance-Operator] mapping
+// Used when EVN-5 (Operator ID) is NOT valued but MSH-4 (Sending Facility) IS valued.
+// Per IG condition: IF EVN-5 NOT VALUED AND (MSH-22 IS VALUED OR MSH-4 IS VALUED)
+// Note: MSH-22 (Sending Responsible Organization) does not exist in HL7v2.3 (added in v2.5),
+// so only MSH-4 (Sending Facility) is checked in this implementation.
+// The sending facility is mapped to Provenance.agent as the "assembler" operator.
+public isolated function mshToProvenanceOperator(Msh msh) returns international401:Provenance {
+    string facilityName = msh.msh4.hd1;
+    international401:ProvenanceAgent agent = {
+        'type: {
+            coding: [{
+                system: "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                code: "assembler",
+                display: "Assembler"
+            }]
+        },
+        who: {display: facilityName != "" ? facilityName : ()}
+    };
+    return {
+        recorded: "",
+        target: [{}],
+        agent: [agent]
+    };
+};
 // ROL → RelatedPerson
 // URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-rol-to-relatedperson.html
 // --------------------------------------------------------------------------------------------#

--- a/utils/v23tofhirr4/mappings.bal
+++ b/utils/v23tofhirr4/mappings.bal
@@ -35,6 +35,20 @@ public isolated function v2ToFhir(string|hl7:Message hl7, V2SegmentToFhirMapper?
     } else {
         hl7msg = hl7;
     }
+    // When no custom overrides are specified, dispatch to the typed message-level mapping
+    // functions that follow the IG ConceptMap exactly (including segment group handling).
+    // Falls back to the generic segment-by-segment approach for unsupported message types
+    // or when custom mapper / service config is provided.
+    if customMapper == () && mapperServiceConf == () {
+        r4:Bundle|error? typedBundle = mapMessageToBundle(hl7msg);
+        if typedBundle is r4:Bundle {
+            return typedBundle.toJson();
+        }
+        if typedBundle is error {
+            return typedBundle;
+        }
+        // typedBundle is () → unsupported message type, fall through to generic
+    }
     if customMapper == () {
         return transformToFhir(hl7msg, defaultMapper, mapperServiceConf);
     }
@@ -564,6 +578,25 @@ public isolated function pd1ToPatient(Pd1 pd1) returns international401:Patient 
     };
 };
 
+// --------------------------------------------------------------------------------------------#
+// PD1-7 → Observation (Living Will)
+// IG dependsOn: IF PD1-7 IS VALUED
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-pd1-to-observation.html
+// --------------------------------------------------------------------------------------------#
+public isolated function pd1ToLivingWillObservation(Pd1 pd1) returns international401:Observation {
+    return {
+        status: "final",
+        code: {
+            coding: [{
+                system: "http://loinc.org",
+                code: "45473-6",
+                display: "Advance directive - living will"
+            }]
+        },
+        valueCodeableConcept: {coding: [{code: pd1.pd17}]}
+    };
+};
+
 public isolated function pidToPatient(Pid pid) returns international401:Patient {
 
     international401:Patient patient = {
@@ -1031,22 +1064,43 @@ public isolated function dg1ToEpisodeOfCare(Dg1 dg1, string? conditionId, string
 }
 
 public isolated function obxToObservation(Obx obx) returns international401:Observation {
+    // IG dependsOn: IF OBX-5.count > 1 AND OBX-2 != "NA" → component observation
+    //               IF OBX-5.count <= 1 OR OBX-2 == "NA"  → single-value observation
+    boolean isComponent = obx.obx5.length() > 1 && obx.obx2 != "NA";
 
+    r4:CodeableConcept code = ceToCodeableConcept(obx.obx3);
     international401:Observation observation = {
-        code: {},
-        valueString: (obx.obx5[0].toString() != "") ? obx.obx5[0].toString() : (),
+        code: code != {} ? code : {},
         dataAbsentReason: idToCodeableConcept(obx.obx11),
         status: "preliminary"
     };
-    r4:CodeableConcept code = ceToCodeableConcept(obx.obx3);
-    if code != {} {
-        observation.code = code;
-    }
     observation.effectiveDateTime = (obx.obx14.ts1 != "") ? tsToDateTime(obx.obx14) : ();
     r4:CodeableConcept method = ceToCodeableConcept(obx.obx17[0]);
     if method != {} {
         observation.method = method;
     }
+
+    if isComponent {
+        // Multi-value OBX: each OBX-5 repetition becomes a component
+        international401:ObservationComponent[] components = [];
+        foreach var val in obx.obx5 {
+            string valStr = val.toString();
+            if valStr != "" {
+                components.push({
+                    code: observation.code,
+                    valueString: valStr
+                });
+            }
+        }
+        if components.length() > 0 {
+            observation.component = components;
+        }
+    } else {
+        // Single-value OBX
+        string singleVal = obx.obx5[0].toString();
+        observation.valueString = singleVal != "" ? singleVal : ();
+    }
+
     return observation;
 };
 
@@ -1805,6 +1859,35 @@ public isolated function txaToDocumentReference(Txa txa) returns international40
     }
 
     return documentReference;
+};
+
+// --------------------------------------------------------------------------------------------#
+// TXA-8 → Provenance (edit history)
+// IG dependsOn: IF TXA-8 IS VALUED (each edit date creates a separate Provenance instance)
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-segment-txa-to-provenance.html
+// --------------------------------------------------------------------------------------------#
+public isolated function txaToProvenance(Txa txa) returns international401:Provenance {
+    international401:Provenance provenance = {
+        recorded: "",
+        target: [{}],
+        agent: [{'type: {}, who: {}}]
+    };
+    // TXA-8 is TS[] (edit date/time repetitions); use first valued entry
+    foreach var ts in txa.txa8 {
+        if ts.ts1 != "" {
+            r4:instant? recorded = tsToInstant(ts);
+            if recorded != () {
+                provenance.recorded = recorded;
+            }
+            break;
+        }
+    }
+    // TXA-9 (originator) → agent.who
+    r4:Reference originator = xcnToReferenceWithName(txa.txa9, "Practitioner");
+    if originator != {} {
+        provenance.agent = [{'type: {coding: [{code: "author"}]}, who: originator}];
+    }
+    return provenance;
 };
 
 // --------------------------------------------------------------------------------------------#

--- a/utils/v23tofhirr4/mappings.bal
+++ b/utils/v23tofhirr4/mappings.bal
@@ -473,8 +473,7 @@ public isolated function mshToMessageHeader(Msh msh) returns international401:Me
         'source: hdToMessageHeaderSource(msh.msh3),
         destination: [hdToMessageHeaderDestination(msh.msh5)],
         eventCoding: msgToCoding(msh.msh9),
-        language: ceToCode(<hl7v23:CE>msh.msh19),
-        eventUri: ""
+        language: ceToCode(<hl7v23:CE>msh.msh19)
     };
     return messageHeader;
 };
@@ -531,18 +530,24 @@ public isolated function evnToProvenance(Evn evn) returns international401:Prove
         agent.push({
             who: xcnToReferenceResult
         });
+    } else {
+        agent.push({
+            who: {
+                display: "Unknown"
+            }
+        });
     }
-    r4:instant recorded = "";
-    r4:dateTime occurredDateTime = "";
-
+    r4:instant recorded = (evn.evn2.ts1 != "") ? hl7DateToFhir(evn.evn2.ts1) :
+        ((evn.evn6.ts1 != "") ? hl7DateToFhir(evn.evn6.ts1) : "1970-01-01T00:00:00Z");
     international401:Provenance provenance = {
         activity: {
             coding: coding
         },
         recorded: recorded,
         agent: agent,
-        occurredDateTime: (occurredDateTime != "") ? occurredDateTime : (),
-        target: []
+        target: [{
+            display: "HL7v2 event source"
+        }]
     };
 
     if evn.evn4 != "" && evn.evn4 != "U" {
@@ -557,9 +562,6 @@ public isolated function evnToProvenance(Evn evn) returns international401:Prove
         ];
     }
 
-    if evn.evn2.ts1 != "" {
-        provenance.recorded = hl7DateToFhir(evn.evn2.ts1);
-    }
     provenance.occurredDateTime = (evn.evn6.ts1 != "") ? hl7DateToFhir(evn.evn6.ts1) : ();
 
     return provenance;
@@ -643,21 +645,25 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
     };
     encounterLocations.push(encounterLoc1);
 
-    international401:EncounterLocation encounterLoc2 = {
-        location: {
-            display: pv1.pv16.pl1 != "" ? pv1.pv16.pl1 : ()
-        },
-        status: getEncounterLocationStatus(pv1.pv16.pl5)
-    };
-    encounterLocations.push(encounterLoc2);
+    if pv1.pv16.pl1 != "" {
+        international401:EncounterLocation encounterLoc2 = {
+            location: {
+                display: pv1.pv16.pl1
+            },
+            status: getEncounterLocationStatus(pv1.pv16.pl5)
+        };
+        encounterLocations.push(encounterLoc2);
+    }
 
-    international401:EncounterLocation encounterLoc3 = {
-        location: {
-            display: pv1.pv111.pl1 != "" ? pv1.pv111.pl1 : ()
-        },
-        status: getEncounterLocationStatus(pv1.pv111.pl5)
-    };
-    encounterLocations.push(encounterLoc3);
+    if pv1.pv111.pl1 != "" {
+        international401:EncounterLocation encounterLoc3 = {
+            location: {
+                display: pv1.pv111.pl1
+            },
+            status: getEncounterLocationStatus(pv1.pv111.pl5)
+        };
+        encounterLocations.push(encounterLoc3);
+    }
 
     international401:EncounterLocation encounterLoc4 = {
         location: {
@@ -1252,7 +1258,9 @@ public isolated function orcToImmunization(Orc orc) returns international401:Imm
 // --------------------------------------------------------------------------------------------#
 public isolated function nk1ToRelatedPerson(Nk1 nk1) returns international401:RelatedPerson {
     international401:RelatedPerson relatedPerson = {
-        patient: {}
+        patient: {
+            reference: "Patient"
+        }
     };
 
     r4:HumanName[] names = [];
@@ -1920,8 +1928,10 @@ public isolated function mshToProvenanceOperator(Msh msh) returns international4
         who: {display: facilityName != "" ? facilityName : ()}
     };
     return {
-        recorded: "",
-        target: [{}],
+        recorded: msh.msh7.ts1 != "" ? hl7DateToFhir(msh.msh7.ts1) : "1970-01-01T00:00:00Z",
+        target: [{
+            display: "Sending facility"
+        }],
         agent: [agent]
     };
 };

--- a/utils/v23tofhirr4/mappings.bal
+++ b/utils/v23tofhirr4/mappings.bal
@@ -708,7 +708,7 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
         if encounterParticipant != {} {
             participants.push(encounterParticipant);
         }
-        i = +1;
+        i += 1;
     }
     i = 0;
     int lenPv18 = 1; // in hl7v23 case
@@ -735,7 +735,7 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
         if encounterParticipant != {} {
             participants.push(encounterParticipant);
         }
-        i = +1;
+        i += 1;
     }
 
     i = 0;
@@ -760,7 +760,7 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
         if encounterParticipant != {} {
             participants.push(encounterParticipant);
         }
-        i = +1;
+        i += 1;
     }
 
     i = 0;
@@ -789,7 +789,7 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
         if encounterParticipant != {} {
             participants.push(encounterParticipant);
         }
-        i = +1;
+        i += 1;
     }
 
     // Define pv1.pv152 hl7v27:PV1, hl7v28:PV1
@@ -814,7 +814,7 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
         if encounterParticipant != {} {
             participants.push(encounterParticipant);
         }
-        i = +1;
+        i += 1;
     }
 
     if pv1.pv12 != "" {
@@ -1317,9 +1317,11 @@ public isolated function nk1ToRelatedPerson(Nk1 nk1) returns international401:Re
     }
     relatedPerson.telecom = (telecoms.length() > 0) ? telecoms : ();
 
-    r4:Period period = {'start: nk1.nk18 != "" ? nk1.nk18 : (), end: nk1.nk19 != "" ? nk1.nk19 : ()};
-    if period != {} {
-        relatedPerson.period = period;
+    if nk1.nk18 != "" || nk1.nk19 != "" {
+        relatedPerson.period = {
+            'start: (nk1.nk18 != "") ? hl7DateToFhir(nk1.nk18) : (),
+            end: (nk1.nk19 != "") ? hl7DateToFhir(nk1.nk19) : ()
+        };
     }
 
     relatedPerson.gender = pidToAdministrativeSex(nk1.nk115);
@@ -1946,12 +1948,11 @@ public isolated function rolToRelatedPerson(Rol rol) returns international401:Re
         relatedPerson.name = [personName];
     }
 
-    r4:Period period = {
-        'start: (rol.rol5.ts1 != "") ? hl7DateToFhir(rol.rol5.ts1) : (),
-        end: (rol.rol6.ts1 != "") ? hl7DateToFhir(rol.rol6.ts1) : ()
-    };
-    if period != {} {
-        relatedPerson.period = period;
+    if rol.rol5.ts1 != "" || rol.rol6.ts1 != "" {
+        relatedPerson.period = {
+            'start: (rol.rol5.ts1 != "") ? hl7DateToFhir(rol.rol5.ts1) : (),
+            end: (rol.rol6.ts1 != "") ? hl7DateToFhir(rol.rol6.ts1) : ()
+        };
     }
 
     return relatedPerson;
@@ -2096,12 +2097,10 @@ public isolated function aigToAppointment(Aig aig) returns international401:Appo
         participant.'type = [resourceType];
     }
 
-    r4:Period period = {};
     if aig.aig8.ts1 != "" {
-        period.'start = hl7DateToFhir(aig.aig8.ts1);
-    }
-    if period != {} {
-        participant.period = period;
+        participant.period = {
+            'start: hl7DateToFhir(aig.aig8.ts1)
+        };
     }
 
     return {
@@ -2123,12 +2122,10 @@ public isolated function ailToAppointment(Ail ail) returns international401:Appo
         participant.actor = {display: ail.ail3.pl1};
     }
 
-    r4:Period period = {};
     if ail.ail6.ts1 != "" {
-        period.'start = hl7DateToFhir(ail.ail6.ts1);
-    }
-    if period != {} {
-        participant.period = period;
+        participant.period = {
+            'start: hl7DateToFhir(ail.ail6.ts1)
+        };
     }
 
     return {
@@ -2156,12 +2153,10 @@ public isolated function aipToAppointment(Aip aip) returns international401:Appo
         participant.'type = [resourceType];
     }
 
-    r4:Period period = {};
     if aip.aip6.ts1 != "" {
-        period.'start = hl7DateToFhir(aip.aip6.ts1);
-    }
-    if period != {} {
-        participant.period = period;
+        participant.period = {
+            'start: hl7DateToFhir(aip.aip6.ts1)
+        };
     }
 
     if aip.aip12.ce1 != "" {

--- a/utils/v23tofhirr4/mappings.bal
+++ b/utils/v23tofhirr4/mappings.bal
@@ -558,7 +558,7 @@ public isolated function evnToProvenance(Evn evn) returns international401:Prove
     }
 
     if evn.evn2.ts1 != "" {
-        provenance.recorded = evn.evn2.ts1;
+        provenance.recorded = hl7DateToFhir(evn.evn2.ts1);
     }
     provenance.occurredDateTime = (evn.evn6.ts1 != "") ? hl7DateToFhir(evn.evn6.ts1) : ();
 
@@ -1498,10 +1498,12 @@ public isolated function rxaToImmunization(Rxa rxa) returns international401:Imm
         decimal|error doseVal = decimal:fromString(rxa.rxa6);
         if doseVal is decimal {
             r4:CodeableConcept doseUnits = ceToCodeableConcept(rxa.rxa7);
+            r4:Coding[] doseUnitCodings = doseUnits.coding ?: [];
+            r4:Coding firstDoseUnitCoding = (doseUnitCodings.length() > 0) ? doseUnitCodings[0] : {};
             immunization.doseQuantity = {
                 value: doseVal,
-                code: doseUnits.coding != () ? doseUnits.coding.toString() : (),
-                unit: doseUnits.coding != () ? doseUnits.coding.toString() : ()
+                code: (firstDoseUnitCoding.code != "") ? firstDoseUnitCoding.code : (),
+                unit: (firstDoseUnitCoding.display != "") ? firstDoseUnitCoding.display : ()
             };
         }
     }
@@ -1525,7 +1527,14 @@ public isolated function rxaToImmunization(Rxa rxa) returns international401:Imm
     if rxa.rxa17.length() > 0 {
         r4:CodeableConcept mfr = ceToCodeableConcept(rxa.rxa17[0]);
         if mfr != {} {
-            immunization.manufacturer = {display: mfr.coding.toString()};
+            r4:Coding[] manufacturerCodings = mfr.coding ?: [];
+            if manufacturerCodings.length() > 0 {
+                r4:Coding manufacturerCoding = manufacturerCodings[0];
+                immunization.manufacturer = {
+                    display: (manufacturerCoding.display != "") ? manufacturerCoding.display :
+                        ((manufacturerCoding.code != "") ? manufacturerCoding.code : ())
+                };
+            }
         }
     }
 

--- a/utils/v23tofhirr4/mappings.bal
+++ b/utils/v23tofhirr4/mappings.bal
@@ -122,19 +122,20 @@ public isolated function segmentToFhir(string segmentName, hl7:Segment segment, 
         "PV1" => {
             [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
             if customMappingResponse[0] {
+                Pv1 pv1Segment = check segment.ensureType(Pv1);
                 Pv1ToPatient? pv1ToPatientResult = impl.pv1ToPatient;
                 if pv1ToPatientResult is Pv1ToPatient {
-                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(pv1ToPatientResult(check segment.ensureType(Pv1)));
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(pv1ToPatientResult(pv1Segment));
                     entries.push(...bundleEntriesResult);
                 }
                 Pv1ToEncounter? pv1ToEncounterResult = impl.pv1ToEncounter;
                 if pv1ToEncounterResult is Pv1ToEncounter {
-                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(pv1ToEncounterResult(check segment.ensureType(Pv1)));
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(pv1ToEncounterResult(pv1Segment));
                     entries.push(...bundleEntriesResult);
                 }
                 Pv1ToCoverage? pv1ToCoverageResult = impl.pv1ToCoverage;
-                if pv1ToCoverageResult is Pv1ToCoverage {
-                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(pv1ToCoverageResult(check segment.ensureType(Pv1)));
+                if pv1ToCoverageResult is Pv1ToCoverage && pv1Segment.pv120.length() > 0 && pv1Segment.pv120[0].fc1 != "" {
+                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(pv1ToCoverageResult(pv1Segment));
                     entries.push(...bundleEntriesResult);
                 }
             }
@@ -316,17 +317,22 @@ public isolated function segmentToFhir(string segmentName, hl7:Segment segment, 
         "RXR" => {
             [boolean, anydata] customMappingResponse = check getCustomSegmentToResourceMapping(serviceconf, segment);
             if customMappingResponse[0] {
+                Rxr rxr = check segment.ensureType(Rxr);
                 RxrToImmunization? rxrToImmunization = impl.rxrToImmunization;
-                if rxrToImmunization is RxrToImmunization {
-                    map<anydata> constructedResource = rxrToImmunization(check segment.ensureType(Rxr));
-                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
-                    entries.push(...bundleEntriesResult);
+                if rxrToImmunization is RxrToImmunization && hasRxrImmunizationData(rxr) {
+                    map<anydata> constructedResource = rxrToImmunization(rxr);
+                    if hasMeaningfulRxrImmunizationResource(constructedResource) {
+                        r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
+                        entries.push(...bundleEntriesResult);
+                    }
                 }
                 RxrToMedicationRequest? rxrToMedicationRequest = impl.rxrToMedicationRequest;
-                if rxrToMedicationRequest is RxrToMedicationRequest {
-                    map<anydata> constructedResource = rxrToMedicationRequest(check segment.ensureType(Rxr));
-                    r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
-                    entries.push(...bundleEntriesResult);
+                if rxrToMedicationRequest is RxrToMedicationRequest && hasRxrMedicationOrderContext(rxr) {
+                    map<anydata> constructedResource = rxrToMedicationRequest(rxr);
+                    if hasMeaningfulRxrMedicationRequestResource(constructedResource) {
+                        r4:BundleEntry[] bundleEntriesResult = populateBundleEntries(constructedResource);
+                        entries.push(...bundleEntriesResult);
+                    }
                 }
             } else {
                 map<anydata> constructedResource = <map<anydata>>customMappingResponse[1];
@@ -466,6 +472,44 @@ public isolated function segmentToFhir(string segmentName, hl7:Segment segment, 
         }
     }
     return entries;
+}
+
+isolated function hasRxrImmunizationData(Rxr rxr) returns boolean {
+    return rxr.rxr1.ce1 != "" || rxr.rxr1.ce2 != "" || rxr.rxr2.ce1 != "" || rxr.rxr2.ce2 != "";
+}
+
+isolated function hasRxrMedicationOrderContext(Rxr rxr) returns boolean {
+    // RXR-4 (administration method) is used here as a medication-order context signal
+    // when dispatching standalone RXR mappings in the generic segment flow.
+    return rxr.rxr4.ce1 != "" || rxr.rxr4.ce2 != "";
+}
+
+isolated function hasMeaningfulRxrImmunizationResource(map<anydata> mappedResource) returns boolean {
+    if mappedResource["route"] is map<anydata> {
+        map<anydata> route = <map<anydata>>mappedResource["route"];
+        if route.keys().length() > 0 {
+            return true;
+        }
+    }
+    if mappedResource["site"] is map<anydata> {
+        map<anydata> site = <map<anydata>>mappedResource["site"];
+        if site.keys().length() > 0 {
+            return true;
+        }
+    }
+    return false;
+}
+
+isolated function hasMeaningfulRxrMedicationRequestResource(map<anydata> mappedResource) returns boolean {
+    if mappedResource["dosageInstruction"] is map<anydata>[] {
+        map<anydata>[] dosageInstruction = <map<anydata>[]>mappedResource["dosageInstruction"];
+        return dosageInstruction.length() > 0;
+    }
+    if mappedResource["medicationCodeableConcept"] is map<anydata> {
+        map<anydata> medicationCodeableConcept = <map<anydata>>mappedResource["medicationCodeableConcept"];
+        return medicationCodeableConcept.keys().length() > 0;
+    }
+    return false;
 }
 
 public isolated function mshToMessageHeader(Msh msh) returns international401:MessageHeader {
@@ -637,13 +681,15 @@ public isolated function pv1ToEncounter(Pv1 pv1) returns international401:Encoun
         status: "in-progress"
     };
     international401:EncounterLocation[] encounterLocations = [];
-    international401:EncounterLocation encounterLoc1 = {
-        location: {
-            display: pv1.pv13.pl1 != "" ? pv1.pv13.pl1 : ()
-        },
-        status: getEncounterLocationStatus(pv1.pv13.pl5)
-    };
-    encounterLocations.push(encounterLoc1);
+    if pv1.pv13.pl1 != "" {
+        international401:EncounterLocation encounterLoc1 = {
+            location: {
+                display: pv1.pv13.pl1
+            },
+            status: getEncounterLocationStatus(pv1.pv13.pl5)
+        };
+        encounterLocations.push(encounterLoc1);
+    }
 
     if pv1.pv16.pl1 != "" {
         international401:EncounterLocation encounterLoc2 = {
@@ -1983,9 +2029,11 @@ public isolated function msaToMessageHeader(Msa msa) returns international401:Me
         "CR" => { responseCode = "transient-error"; }
         _ => { responseCode = "ok"; }
     }
+    string eventUri = string `urn:hl7v2:msa:${(msa.msa1 != "") ? msa.msa1 : "UNSPECIFIED"}`;
+    string sourceEndpoint = (msa.msa2 != "") ? string `urn:hl7v2:message-control-id:${msa.msa2}` : "urn:source:unknown";
     international401:MessageHeader messageHeader = {
-        'source: {endpoint: ""},
-        eventUri: "",
+        'source: {endpoint: sourceEndpoint},
+        eventUri: eventUri,
         response: {
             identifier: msa.msa2,
             code: responseCode
@@ -2016,9 +2064,18 @@ public isolated function mrgToAccount(Mrg mrg) returns international401:Account 
 public isolated function in1ToCoverage(In1 in1) returns international401:Coverage {
     international401:Coverage coverage = {
         status: "active",
-        beneficiary: {},
-        payor: [{}]
+        beneficiary: {display: "Unknown Beneficiary"},
+        payor: [{display: "Unknown Payor"}]
     };
+
+    if in1.hasKey("in4") {
+        anydata in14Value = in1["in4"];
+        if in14Value is hl7v23:XON && in14Value.xon1 != "" {
+            coverage.beneficiary = {
+                display: in14Value.xon1
+            };
+        }
+    }
 
     r4:Identifier planId = (in1.in12.ce1 != "") ? {value: in1.in12.ce1} : {};
     if planId != {} {
@@ -2031,7 +2088,9 @@ public isolated function in1ToCoverage(In1 in1) returns international401:Coverag
             payors.push({display: item.xon1});
         }
     }
-    coverage.payor = (payors.length() > 0) ? payors : [{}];
+    if payors.length() > 0 {
+        coverage.payor = payors;
+    }
 
     if in1.in112 != "" || in1.in113 != "" {
         coverage.period = {
@@ -2079,8 +2138,8 @@ public isolated function in3ToCareTeam(In3 in3) returns international401:CareTea
 public isolated function pv1ToCoverage(Pv1 pv1) returns international401:Coverage {
     international401:Coverage coverage = {
         status: "active",
-        beneficiary: {},
-        payor: [{}]
+        beneficiary: {reference: "Patient"},
+        payor: [{display: "Unknown Payor"}]
     };
     if pv1.pv120.length() > 0 && pv1.pv120[0].fc1 != "" {
         coverage.'type = {coding: [{code: pv1.pv120[0].fc1}]};
@@ -2099,7 +2158,20 @@ public isolated function aigToAppointment(Aig aig) returns international401:Appo
 
     r4:CodeableConcept resourceId = ceToCodeableConcept(aig.aig3);
     if resourceId != {} {
-        participant.actor = {display: resourceId.coding.toString()};
+        string actorDisplay = "";
+        r4:Coding[] codings = resourceId.coding ?: [];
+        if codings.length() > 0 {
+            string? display = codings[0].display;
+            r4:code? code = codings[0].code;
+            if display is string && display != "" {
+                actorDisplay = display;
+            } else if code is string && code != "" {
+                actorDisplay = code;
+            }
+        }
+        if actorDisplay != "" {
+            participant.actor = {display: actorDisplay};
+        }
     }
 
     r4:CodeableConcept resourceType = ceToCodeableConcept(aig.aig4);

--- a/utils/v23tofhirr4/message_mappings.bal
+++ b/utils/v23tofhirr4/message_mappings.bal
@@ -80,6 +80,11 @@ public isolated function adtA01ToBundle(hl7v23:ADT_A01 message) returns r4:Bundl
     entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
     // EVN → Provenance
     entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // IG: IF EVN-5 NOT VALUED AND (MSH-22 IS VALUED OR MSH-4 IS VALUED) -> MSH[Provenance-Operator]
+    // MSH-22 does not exist in HL7v2.3 (added in v2.5); only MSH-4 (Sending Facility) is checked.
+    if message.evn.evn5.xcn1 == "" && message.msh.msh4.hd1 != "" {
+        entries.push(...populateBundleEntries(mshToProvenanceOperator(message.msh)));
+    }
     // PID → Patient
     entries.push(...populateBundleEntries(pidToPatient(message.pid)));
     // PD1 → Patient (optional)
@@ -91,9 +96,14 @@ public isolated function adtA01ToBundle(hl7v23:ADT_A01 message) returns r4:Bundl
             entries.push(...populateBundleEntries(pd1ToLivingWillObservation(pd1)));
         }
     }
-    // NK1 → RelatedPerson + Patient
+    // NK1 → RelatedPerson (IG dependsOn: IF NK1-3.1 NOT IN ("EMR","E","F","I","S"))
+    // NK1 → Patient (always, regardless of relationship type)
+    // Emergency/agency relationship types map to Patient contact only, not RelatedPerson.
     foreach hl7v23:NK1 nk1 in message.nk1 {
-        entries.push(...populateBundleEntries(nk1ToRelatedPerson(nk1)));
+        string nk1Rel = nk1.nk13.ce1;
+        if nk1Rel != "EMR" && nk1Rel != "E" && nk1Rel != "F" && nk1Rel != "I" && nk1Rel != "S" {
+            entries.push(...populateBundleEntries(nk1ToRelatedPerson(nk1)));
+        }
         entries.push(...populateBundleEntries(nk1ToPatient(nk1)));
     }
     // PV1 → Encounter + Patient
@@ -120,18 +130,21 @@ public isolated function adtA01ToBundle(hl7v23:ADT_A01 message) returns r4:Bundl
     foreach hl7v23:DG1 dg1 in message.dg1 {
         entries.push(...populateBundleEntries(dg1ToCondition(dg1)));
     }
-    // PROCEDURE group → Procedure + RelatedPerson (ROL)
+    // IG: follow:PID.ROL (ROL after PID/PD1) has two conditional targets:
+    //   IF ROL-3.1 = "PP" AND ROL-3.3 = "HL70443" → Patient[1] (ROL[Patient-GeneralPractitioner])
+    //   IF ROL-3.3 = "HL70443" AND ROL-3.1 != "PP" → CareTeam[1] (ROL[CareTeam])
+    // IG: follow:PV1.ROL → Encounter[1] (ROL[Encounter-PractitionerRole]) unconditionally
+    // These ROL segments are NOT exposed as typed fields in the hl7v23:ADT_A01 record;
+    // they are only reachable via the generic entries() iteration. Cannot be implemented here.
+    // PROCEDURE group → Procedure
+    // IG: PROCEDURE.ROL has no defined FHIR target; no resource created from it per spec.
     // Guard: pr11 (set-ID) is "" for Ballerina default empty instances
     foreach hl7v23:ADT_A01_PROCEDURE proc in message.procedure {
         if proc.pr1.pr11 == "" {
             continue;
         }
         entries.push(...populateBundleEntries(pr1ToProcedure(proc.pr1)));
-        foreach hl7v23:ROL rol in proc.rol {
-            if rol.rol1.ei1 != "" {
-                entries.push(...populateBundleEntries(rolToRelatedPerson(rol)));
-            }
-        }
+        // IG: PROCEDURE.ROL has no FHIR target; skipped.
     }
     // INSURANCE group → Coverage + CareTeam (IN3)
     foreach hl7v23:ADT_A01_INSURANCE ins in message.insurance {
@@ -162,6 +175,11 @@ public isolated function adtA02ToBundle(hl7v23:ADT_A02 message) returns r4:Bundl
     entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
     // EVN → Provenance
     entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // IG: IF EVN-5 NOT VALUED AND (MSH-22 IS VALUED OR MSH-4 IS VALUED) -> MSH[Provenance-Operator]
+    // MSH-22 does not exist in HL7v2.3 (added in v2.5); only MSH-4 (Sending Facility) is checked.
+    if message.evn.evn5.xcn1 == "" && message.msh.msh4.hd1 != "" {
+        entries.push(...populateBundleEntries(mshToProvenanceOperator(message.msh)));
+    }
     // PID → Patient
     entries.push(...populateBundleEntries(pidToPatient(message.pid)));
     // PD1 → Patient (optional)
@@ -207,6 +225,11 @@ public isolated function adtA05ToBundle(hl7v23:ADT_A05 message) returns r4:Bundl
     entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
     // EVN → Provenance
     entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // IG: IF EVN-5 NOT VALUED AND (MSH-22 IS VALUED OR MSH-4 IS VALUED) -> MSH[Provenance-Operator]
+    // MSH-22 does not exist in HL7v2.3 (added in v2.5); only MSH-4 (Sending Facility) is checked.
+    if message.evn.evn5.xcn1 == "" && message.msh.msh4.hd1 != "" {
+        entries.push(...populateBundleEntries(mshToProvenanceOperator(message.msh)));
+    }
     // PID → Patient
     entries.push(...populateBundleEntries(pidToPatient(message.pid)));
     // PD1 → Patient (optional)
@@ -247,18 +270,16 @@ public isolated function adtA05ToBundle(hl7v23:ADT_A05 message) returns r4:Bundl
     foreach hl7v23:DG1 dg1 in message.dg1 {
         entries.push(...populateBundleEntries(dg1ToCondition(dg1)));
     }
-    // PROCEDURE group → Procedure + RelatedPerson (ROL)
+    // IG: follow:PID.ROL conditional targets (ROL-3.1/3.3 conditions) and follow:PV1.ROL
+    // are not accessible as typed fields in hl7v23:ADT_A05; skipped.
+    // PROCEDURE group → Procedure
+    // IG: PROCEDURE.ROL has no defined FHIR target per CSV mapping; skipped.
     // Guard: pr11 (set-ID) is "" for Ballerina default empty instances
     foreach hl7v23:ADT_A05_PROCEDURE proc in message.procedure {
         if proc.pr1.pr11 == "" {
             continue;
         }
         entries.push(...populateBundleEntries(pr1ToProcedure(proc.pr1)));
-        foreach hl7v23:ROL rol in proc.rol {
-            if rol.rol1.ei1 != "" {
-                entries.push(...populateBundleEntries(rolToRelatedPerson(rol)));
-            }
-        }
     }
     // INSURANCE group → Coverage + CareTeam (IN3)
     foreach hl7v23:ADT_A05_INSURANCE ins in message.insurance {
@@ -289,6 +310,11 @@ public isolated function adtA06ToBundle(hl7v23:ADT_A06 message) returns r4:Bundl
     entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
     // EVN → Provenance
     entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // IG: IF EVN-5 NOT VALUED AND (MSH-22 IS VALUED OR MSH-4 IS VALUED) -> MSH[Provenance-Operator]
+    // MSH-22 does not exist in HL7v2.3 (added in v2.5); only MSH-4 (Sending Facility) is checked.
+    if message.evn.evn5.xcn1 == "" && message.msh.msh4.hd1 != "" {
+        entries.push(...populateBundleEntries(mshToProvenanceOperator(message.msh)));
+    }
     // PID → Patient
     entries.push(...populateBundleEntries(pidToPatient(message.pid)));
     // PD1 → Patient (optional)
@@ -334,18 +360,16 @@ public isolated function adtA06ToBundle(hl7v23:ADT_A06 message) returns r4:Bundl
     foreach hl7v23:DG1 dg1 in message.dg1 {
         entries.push(...populateBundleEntries(dg1ToCondition(dg1)));
     }
-    // PROCEDURE group → Procedure + RelatedPerson (ROL)
+    // IG: follow:PID.ROL conditional targets (ROL-3.1/3.3 conditions) and follow:PV1.ROL
+    // are not accessible as typed fields in hl7v23:ADT_A06; skipped.
+    // PROCEDURE group → Procedure
+    // IG: PROCEDURE.ROL has no defined FHIR target per CSV mapping; skipped.
     // Guard: pr11 (set-ID) is "" for Ballerina default empty instances
     foreach hl7v23:ADT_A06_PROCEDURE proc in message.procedure {
         if proc.pr1.pr11 == "" {
             continue;
         }
         entries.push(...populateBundleEntries(pr1ToProcedure(proc.pr1)));
-        foreach hl7v23:ROL rol in proc.rol {
-            if rol.rol1.ei1 != "" {
-                entries.push(...populateBundleEntries(rolToRelatedPerson(rol)));
-            }
-        }
     }
     // INSURANCE group → Coverage + CareTeam (IN3)
     foreach hl7v23:ADT_A06_INSURANCE ins in message.insurance {
@@ -376,6 +400,11 @@ public isolated function adtA09ToBundle(hl7v23:ADT_A09 message) returns r4:Bundl
     entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
     // EVN → Provenance
     entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // IG: IF EVN-5 NOT VALUED AND (MSH-22 IS VALUED OR MSH-4 IS VALUED) -> MSH[Provenance-Operator]
+    // MSH-22 does not exist in HL7v2.3 (added in v2.5); only MSH-4 (Sending Facility) is checked.
+    if message.evn.evn5.xcn1 == "" && message.msh.msh4.hd1 != "" {
+        entries.push(...populateBundleEntries(mshToProvenanceOperator(message.msh)));
+    }
     // PID → Patient
     entries.push(...populateBundleEntries(pidToPatient(message.pid)));
     // PD1 → Patient (optional)
@@ -425,6 +454,11 @@ public isolated function adtA11ToBundle(hl7v23:ADT_A11 message) returns r4:Bundl
     entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
     // EVN → Provenance
     entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // IG: IF EVN-5 NOT VALUED AND (MSH-22 IS VALUED OR MSH-4 IS VALUED) -> MSH[Provenance-Operator]
+    // MSH-22 does not exist in HL7v2.3 (added in v2.5); only MSH-4 (Sending Facility) is checked.
+    if message.evn.evn5.xcn1 == "" && message.msh.msh4.hd1 != "" {
+        entries.push(...populateBundleEntries(mshToProvenanceOperator(message.msh)));
+    }
     // PID → Patient
     entries.push(...populateBundleEntries(pidToPatient(message.pid)));
     // PD1 → Patient (optional)
@@ -474,6 +508,11 @@ public isolated function adtA17ToBundle(hl7v23:ADT_A17 message) returns r4:Bundl
     entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
     // EVN → Provenance
     entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // IG: IF EVN-5 NOT VALUED AND (MSH-22 IS VALUED OR MSH-4 IS VALUED) -> MSH[Provenance-Operator]
+    // MSH-22 does not exist in HL7v2.3 (added in v2.5); only MSH-4 (Sending Facility) is checked.
+    if message.evn.evn5.xcn1 == "" && message.msh.msh4.hd1 != "" {
+        entries.push(...populateBundleEntries(mshToProvenanceOperator(message.msh)));
+    }
     // PID → Patient
     entries.push(...populateBundleEntries(pidToPatient(message.pid)));
     // PD1 → Patient (optional)
@@ -598,16 +637,13 @@ public isolated function ormO01ToBundle(hl7v23:ORM_O01 message) returns r4:Bundl
                 entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
             }
         }
-        // INSURANCE sub-groups → Coverage + CareTeam
+        // INSURANCE sub-groups → Coverage
+        // IG: IN3 content is incorporated into Coverage (no separate CareTeam for ORM_O01)
         foreach hl7v23:ORM_O01_INSURANCE ins in patient.orm_o01_insurance {
             if ins.in1.in11 == "" {
                 continue;
             }
             entries.push(...populateBundleEntries(in1ToCoverage(ins.in1)));
-            hl7v23:IN3? in3 = ins.in3;
-            if in3 != () {
-                entries.push(...populateBundleEntries(in3ToCareTeam(in3)));
-            }
         }
     }
 
@@ -639,7 +675,7 @@ public isolated function ormO01ToBundle(hl7v23:ORM_O01 message) returns r4:Bundl
                     // IG dependsOn: IF PID IS VALUED → ServiceRequest
                     entries.push(...populateBundleEntries(obrToServiceRequest(obr)));
                 }
-                entries.push(...populateBundleEntries(obrToDiagnosticReport(obr)));
+                // IG: IF PID NOT VALUED → SupplyRequest (not yet implemented; no mapping function available)
             }
             hl7v23:RXO? rxo = detail.orm_o01_order_detail_segment.rxo;
             if rxo != () {
@@ -702,7 +738,12 @@ public isolated function siuS12ToBundle(hl7v23:SIU_S12 message) returns r4:Bundl
     entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
     // SCH → Appointment
     entries.push(...populateBundleEntries(schToAppointment(message.sch)));
+    // IG condition: IF SCH-26 OR SCH-27 VALUED → SCH[ServiceRequest] (Placer/Filler order numbers)
+    // SCH-26 and SCH-27 do not exist in HL7v2.3 (the SCH segment only defines up to SCH-25).
+    // ServiceRequest from SCH cannot be created in this v2.3 implementation.
     // NTE → Observation (message-level notes)
+    // IG: NTE → Appointment[1].comment (NTE[Appointment-Comment]); mapped to Observation as pragmatic fallback
+    //     since no nteToAppointmentComment function exists in this implementation.
     foreach hl7v23:NTE nte in message.nte {
         entries.push(...populateBundleEntries(nteToObservation(nte)));
     }
@@ -841,17 +882,14 @@ public isolated function vxuV04ToBundle(hl7v23:VXU_V04 message) returns r4:Bundl
         }
     }
 
-    // INSURANCE groups → Coverage + CareTeam
+    // INSURANCE groups → Coverage
+    // IG: IN3 content is incorporated into Coverage (no separate CareTeam for VXU_V04)
     // Guard: in11 (set-ID) is "" for Ballerina default empty instances
     foreach hl7v23:VXU_V04_INSURANCE ins in message.insurance {
         if ins.in1.in11 == "" {
             continue;
         }
         entries.push(...populateBundleEntries(in1ToCoverage(ins.in1)));
-        hl7v23:IN3? in3 = ins.in3;
-        if in3 != () {
-            entries.push(...populateBundleEntries(in3ToCareTeam(in3)));
-        }
     }
 
     // ORDER groups → Immunization + MedicationRequest + Observation

--- a/utils/v23tofhirr4/message_mappings.bal
+++ b/utils/v23tofhirr4/message_mappings.bal
@@ -1,0 +1,892 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// --------------------------------------------------------------------------------------------#
+// Source HL7 Version 2 to FHIR - Message Maps
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/message_maps.html
+// --------------------------------------------------------------------------------------------#
+
+import ballerinax/health.fhir.r4 as r4;
+import ballerinax/health.hl7v2 as hl7;
+import ballerinax/health.hl7v23;
+
+// --------------------------------------------------------------------------------------------#
+// Message-type dispatcher: maps a parsed HL7v23 message to a typed FHIR Bundle using the
+// IG-specified message-level ConceptMap. Returns () for unsupported message types so the
+// caller can fall back to the generic segment-by-segment approach (transformToFhir).
+// ORU_R01 is excluded here because its PATIENT_RESULT segment groups are stored as dynamic
+// record fields; the generic path handles them better via message.entries() iteration.
+// --------------------------------------------------------------------------------------------#
+isolated function mapMessageToBundle(hl7:Message message) returns r4:Bundle|error? {
+    match message.name {
+        "ADT_A01" => {
+            return adtA01ToBundle(check message.ensureType(hl7v23:ADT_A01));
+        }
+        "ADT_A02" => {
+            return adtA02ToBundle(check message.ensureType(hl7v23:ADT_A02));
+        }
+        "ADT_A05" => {
+            return adtA05ToBundle(check message.ensureType(hl7v23:ADT_A05));
+        }
+        "ADT_A06" => {
+            return adtA06ToBundle(check message.ensureType(hl7v23:ADT_A06));
+        }
+        "ADT_A09" => {
+            return adtA09ToBundle(check message.ensureType(hl7v23:ADT_A09));
+        }
+        "ADT_A11" => {
+            return adtA11ToBundle(check message.ensureType(hl7v23:ADT_A11));
+        }
+        "ADT_A17" => {
+            return adtA17ToBundle(check message.ensureType(hl7v23:ADT_A17));
+        }
+        "MDM_T02" => {
+            return mdmT02ToBundle(check message.ensureType(hl7v23:MDM_T02));
+        }
+        "ORM_O01" => {
+            return ormO01ToBundle(check message.ensureType(hl7v23:ORM_O01));
+        }
+        "SIU_S12" => {
+            return siuS12ToBundle(check message.ensureType(hl7v23:SIU_S12));
+        }
+        "VXU_V04" => {
+            return vxuV04ToBundle(check message.ensureType(hl7v23:VXU_V04));
+        }
+    }
+    // ORU_R01 and all other unsupported types → fall back to generic segment mapping
+    return ();
+}
+
+// --------------------------------------------------------------------------------------------#
+// ADT_A01 (Admit/Visit Notification) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-adt-a01-to-bundle.html
+// Segments: MSH, EVN, PID, PD1, NK1, PV1, PV2, OBX, AL1, DG1, PROCEDURE(PR1,ROL), INSURANCE(IN1,IN3)
+// --------------------------------------------------------------------------------------------#
+public isolated function adtA01ToBundle(hl7v23:ADT_A01 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // EVN → Provenance
+    entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // PID → Patient
+    entries.push(...populateBundleEntries(pidToPatient(message.pid)));
+    // PD1 → Patient (optional)
+    // PD1-7 → Observation (Living Will): IG dependsOn IF PD1-7 IS VALUED
+    hl7v23:PD1? pd1 = message.pd1;
+    if pd1 != () {
+        entries.push(...populateBundleEntries(pd1ToPatient(pd1)));
+        if pd1.pd17 != "" {
+            entries.push(...populateBundleEntries(pd1ToLivingWillObservation(pd1)));
+        }
+    }
+    // NK1 → RelatedPerson + Patient
+    foreach hl7v23:NK1 nk1 in message.nk1 {
+        entries.push(...populateBundleEntries(nk1ToRelatedPerson(nk1)));
+        entries.push(...populateBundleEntries(nk1ToPatient(nk1)));
+    }
+    // PV1 → Encounter + Patient
+    entries.push(...populateBundleEntries(pv1ToEncounter(message.pv1)));
+    entries.push(...populateBundleEntries(pv1ToPatient(message.pv1)));
+    // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+    if message.pv1.pv120[0].fc1 != "" {
+        entries.push(...populateBundleEntries(pv1ToCoverage(message.pv1)));
+    }
+    // PV2 → Encounter (optional)
+    hl7v23:PV2? pv2 = message.pv2;
+    if pv2 != () {
+        entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
+    }
+    // OBX → Observation (single or component based on OBX-2/OBX-5 count — handled in obxToObservation)
+    foreach hl7v23:OBX obx in message.obx {
+        entries.push(...populateBundleEntries(obxToObservation(obx)));
+    }
+    // AL1 → AllergyIntolerance
+    foreach hl7v23:AL1 al1 in message.al1 {
+        entries.push(...populateBundleEntries(al1ToAllerygyIntolerance(al1)));
+    }
+    // DG1 → Condition
+    foreach hl7v23:DG1 dg1 in message.dg1 {
+        entries.push(...populateBundleEntries(dg1ToCondition(dg1)));
+    }
+    // PROCEDURE group → Procedure + RelatedPerson (ROL)
+    // Guard: pr11 (set-ID) is "" for Ballerina default empty instances
+    foreach hl7v23:ADT_A01_PROCEDURE proc in message.procedure {
+        if proc.pr1.pr11 == "" {
+            continue;
+        }
+        entries.push(...populateBundleEntries(pr1ToProcedure(proc.pr1)));
+        foreach hl7v23:ROL rol in proc.rol {
+            if rol.rol1.ei1 != "" {
+                entries.push(...populateBundleEntries(rolToRelatedPerson(rol)));
+            }
+        }
+    }
+    // INSURANCE group → Coverage + CareTeam (IN3)
+    foreach hl7v23:ADT_A01_INSURANCE ins in message.insurance {
+        if ins.in1.in11 == "" {
+            continue;
+        }
+        entries.push(...populateBundleEntries(in1ToCoverage(ins.in1)));
+        hl7v23:IN3? in3 = ins.in3;
+        if in3 != () {
+            entries.push(...populateBundleEntries(in3ToCareTeam(in3)));
+        }
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// ADT_A02 (Transfer a Patient) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-adt-a02-to-bundle.html
+// Segments: MSH, EVN, PID, PD1, PV1, PV2, OBX
+// --------------------------------------------------------------------------------------------#
+public isolated function adtA02ToBundle(hl7v23:ADT_A02 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // EVN → Provenance
+    entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // PID → Patient
+    entries.push(...populateBundleEntries(pidToPatient(message.pid)));
+    // PD1 → Patient (optional)
+    // PD1-7 → Observation (Living Will): IG dependsOn IF PD1-7 IS VALUED
+    hl7v23:PD1? pd1 = message.pd1;
+    if pd1 != () {
+        entries.push(...populateBundleEntries(pd1ToPatient(pd1)));
+        if pd1.pd17 != "" {
+            entries.push(...populateBundleEntries(pd1ToLivingWillObservation(pd1)));
+        }
+    }
+    // PV1 → Encounter + Patient
+    entries.push(...populateBundleEntries(pv1ToEncounter(message.pv1)));
+    entries.push(...populateBundleEntries(pv1ToPatient(message.pv1)));
+    // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+    if message.pv1.pv120[0].fc1 != "" {
+        entries.push(...populateBundleEntries(pv1ToCoverage(message.pv1)));
+    }
+    // PV2 → Encounter (optional)
+    hl7v23:PV2? pv2 = message.pv2;
+    if pv2 != () {
+        entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
+    }
+    // OBX → Observation
+    foreach hl7v23:OBX obx in message.obx {
+        entries.push(...populateBundleEntries(obxToObservation(obx)));
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// ADT_A05 (Pre-Admit a Patient) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-adt-a05-to-bundle.html
+// Segments: MSH, EVN, PID, PD1, NK1, PV1, PV2, OBX, AL1, DG1, PROCEDURE(PR1,ROL), INSURANCE(IN1,IN3)
+// --------------------------------------------------------------------------------------------#
+public isolated function adtA05ToBundle(hl7v23:ADT_A05 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // EVN → Provenance
+    entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // PID → Patient
+    entries.push(...populateBundleEntries(pidToPatient(message.pid)));
+    // PD1 → Patient (optional)
+    // PD1-7 → Observation (Living Will): IG dependsOn IF PD1-7 IS VALUED
+    hl7v23:PD1? pd1 = message.pd1;
+    if pd1 != () {
+        entries.push(...populateBundleEntries(pd1ToPatient(pd1)));
+        if pd1.pd17 != "" {
+            entries.push(...populateBundleEntries(pd1ToLivingWillObservation(pd1)));
+        }
+    }
+    // NK1 → RelatedPerson + Patient
+    foreach hl7v23:NK1 nk1 in message.nk1 {
+        entries.push(...populateBundleEntries(nk1ToRelatedPerson(nk1)));
+        entries.push(...populateBundleEntries(nk1ToPatient(nk1)));
+    }
+    // PV1 → Encounter + Patient
+    entries.push(...populateBundleEntries(pv1ToEncounter(message.pv1)));
+    entries.push(...populateBundleEntries(pv1ToPatient(message.pv1)));
+    // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+    if message.pv1.pv120[0].fc1 != "" {
+        entries.push(...populateBundleEntries(pv1ToCoverage(message.pv1)));
+    }
+    // PV2 → Encounter (optional)
+    hl7v23:PV2? pv2 = message.pv2;
+    if pv2 != () {
+        entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
+    }
+    // OBX → Observation
+    foreach hl7v23:OBX obx in message.obx {
+        entries.push(...populateBundleEntries(obxToObservation(obx)));
+    }
+    // AL1 → AllergyIntolerance
+    foreach hl7v23:AL1 al1 in message.al1 {
+        entries.push(...populateBundleEntries(al1ToAllerygyIntolerance(al1)));
+    }
+    // DG1 → Condition
+    foreach hl7v23:DG1 dg1 in message.dg1 {
+        entries.push(...populateBundleEntries(dg1ToCondition(dg1)));
+    }
+    // PROCEDURE group → Procedure + RelatedPerson (ROL)
+    // Guard: pr11 (set-ID) is "" for Ballerina default empty instances
+    foreach hl7v23:ADT_A05_PROCEDURE proc in message.procedure {
+        if proc.pr1.pr11 == "" {
+            continue;
+        }
+        entries.push(...populateBundleEntries(pr1ToProcedure(proc.pr1)));
+        foreach hl7v23:ROL rol in proc.rol {
+            if rol.rol1.ei1 != "" {
+                entries.push(...populateBundleEntries(rolToRelatedPerson(rol)));
+            }
+        }
+    }
+    // INSURANCE group → Coverage + CareTeam (IN3)
+    foreach hl7v23:ADT_A05_INSURANCE ins in message.insurance {
+        if ins.in1.in11 == "" {
+            continue;
+        }
+        entries.push(...populateBundleEntries(in1ToCoverage(ins.in1)));
+        hl7v23:IN3? in3 = ins.in3;
+        if in3 != () {
+            entries.push(...populateBundleEntries(in3ToCareTeam(in3)));
+        }
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// ADT_A06 (Change an Outpatient to an Inpatient) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-adt-a06-to-bundle.html
+// Segments: MSH, EVN, PID, PD1, MRG, NK1, PV1, PV2, OBX, AL1, DG1, PROCEDURE, INSURANCE
+// --------------------------------------------------------------------------------------------#
+public isolated function adtA06ToBundle(hl7v23:ADT_A06 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // EVN → Provenance
+    entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // PID → Patient
+    entries.push(...populateBundleEntries(pidToPatient(message.pid)));
+    // PD1 → Patient (optional)
+    // PD1-7 → Observation (Living Will): IG dependsOn IF PD1-7 IS VALUED
+    hl7v23:PD1? pd1 = message.pd1;
+    if pd1 != () {
+        entries.push(...populateBundleEntries(pd1ToPatient(pd1)));
+        if pd1.pd17 != "" {
+            entries.push(...populateBundleEntries(pd1ToLivingWillObservation(pd1)));
+        }
+    }
+    // MRG → Account (optional)
+    hl7v23:MRG? mrg = message.mrg;
+    if mrg != () {
+        entries.push(...populateBundleEntries(mrgToAccount(mrg)));
+    }
+    // NK1 → RelatedPerson + Patient
+    foreach hl7v23:NK1 nk1 in message.nk1 {
+        entries.push(...populateBundleEntries(nk1ToRelatedPerson(nk1)));
+        entries.push(...populateBundleEntries(nk1ToPatient(nk1)));
+    }
+    // PV1 → Encounter + Patient
+    entries.push(...populateBundleEntries(pv1ToEncounter(message.pv1)));
+    entries.push(...populateBundleEntries(pv1ToPatient(message.pv1)));
+    // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+    if message.pv1.pv120[0].fc1 != "" {
+        entries.push(...populateBundleEntries(pv1ToCoverage(message.pv1)));
+    }
+    // PV2 → Encounter (optional)
+    hl7v23:PV2? pv2 = message.pv2;
+    if pv2 != () {
+        entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
+    }
+    // OBX → Observation
+    foreach hl7v23:OBX obx in message.obx {
+        entries.push(...populateBundleEntries(obxToObservation(obx)));
+    }
+    // AL1 → AllergyIntolerance
+    foreach hl7v23:AL1 al1 in message.al1 {
+        entries.push(...populateBundleEntries(al1ToAllerygyIntolerance(al1)));
+    }
+    // DG1 → Condition
+    foreach hl7v23:DG1 dg1 in message.dg1 {
+        entries.push(...populateBundleEntries(dg1ToCondition(dg1)));
+    }
+    // PROCEDURE group → Procedure + RelatedPerson (ROL)
+    // Guard: pr11 (set-ID) is "" for Ballerina default empty instances
+    foreach hl7v23:ADT_A06_PROCEDURE proc in message.procedure {
+        if proc.pr1.pr11 == "" {
+            continue;
+        }
+        entries.push(...populateBundleEntries(pr1ToProcedure(proc.pr1)));
+        foreach hl7v23:ROL rol in proc.rol {
+            if rol.rol1.ei1 != "" {
+                entries.push(...populateBundleEntries(rolToRelatedPerson(rol)));
+            }
+        }
+    }
+    // INSURANCE group → Coverage + CareTeam (IN3)
+    foreach hl7v23:ADT_A06_INSURANCE ins in message.insurance {
+        if ins.in1.in11 == "" {
+            continue;
+        }
+        entries.push(...populateBundleEntries(in1ToCoverage(ins.in1)));
+        hl7v23:IN3? in3 = ins.in3;
+        if in3 != () {
+            entries.push(...populateBundleEntries(in3ToCareTeam(in3)));
+        }
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// ADT_A09 (Patient Departing - Tracking) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-adt-a09-to-bundle.html
+// Segments: MSH, EVN, PID, PD1, PV1, PV2, OBX, DG1
+// --------------------------------------------------------------------------------------------#
+public isolated function adtA09ToBundle(hl7v23:ADT_A09 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // EVN → Provenance
+    entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // PID → Patient
+    entries.push(...populateBundleEntries(pidToPatient(message.pid)));
+    // PD1 → Patient (optional)
+    // PD1-7 → Observation (Living Will): IG dependsOn IF PD1-7 IS VALUED
+    hl7v23:PD1? pd1 = message.pd1;
+    if pd1 != () {
+        entries.push(...populateBundleEntries(pd1ToPatient(pd1)));
+        if pd1.pd17 != "" {
+            entries.push(...populateBundleEntries(pd1ToLivingWillObservation(pd1)));
+        }
+    }
+    // PV1 → Encounter + Patient
+    entries.push(...populateBundleEntries(pv1ToEncounter(message.pv1)));
+    entries.push(...populateBundleEntries(pv1ToPatient(message.pv1)));
+    // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+    if message.pv1.pv120[0].fc1 != "" {
+        entries.push(...populateBundleEntries(pv1ToCoverage(message.pv1)));
+    }
+    // PV2 → Encounter (optional)
+    hl7v23:PV2? pv2 = message.pv2;
+    if pv2 != () {
+        entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
+    }
+    // OBX → Observation
+    foreach hl7v23:OBX obx in message.obx {
+        entries.push(...populateBundleEntries(obxToObservation(obx)));
+    }
+    // DG1 → Condition
+    foreach hl7v23:DG1 dg1 in message.dg1 {
+        entries.push(...populateBundleEntries(dg1ToCondition(dg1)));
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// ADT_A11 (Cancel Admit/Visit Notification) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-adt-a11-to-bundle.html
+// Segments: MSH, EVN, PID, PD1, PV1, PV2, OBX, DG1
+// --------------------------------------------------------------------------------------------#
+public isolated function adtA11ToBundle(hl7v23:ADT_A11 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // EVN → Provenance
+    entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // PID → Patient
+    entries.push(...populateBundleEntries(pidToPatient(message.pid)));
+    // PD1 → Patient (optional)
+    // PD1-7 → Observation (Living Will): IG dependsOn IF PD1-7 IS VALUED
+    hl7v23:PD1? pd1 = message.pd1;
+    if pd1 != () {
+        entries.push(...populateBundleEntries(pd1ToPatient(pd1)));
+        if pd1.pd17 != "" {
+            entries.push(...populateBundleEntries(pd1ToLivingWillObservation(pd1)));
+        }
+    }
+    // PV1 → Encounter + Patient
+    entries.push(...populateBundleEntries(pv1ToEncounter(message.pv1)));
+    entries.push(...populateBundleEntries(pv1ToPatient(message.pv1)));
+    // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+    if message.pv1.pv120[0].fc1 != "" {
+        entries.push(...populateBundleEntries(pv1ToCoverage(message.pv1)));
+    }
+    // PV2 → Encounter (optional)
+    hl7v23:PV2? pv2 = message.pv2;
+    if pv2 != () {
+        entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
+    }
+    // OBX → Observation
+    foreach hl7v23:OBX obx in message.obx {
+        entries.push(...populateBundleEntries(obxToObservation(obx)));
+    }
+    // DG1 → Condition
+    foreach hl7v23:DG1 dg1 in message.dg1 {
+        entries.push(...populateBundleEntries(dg1ToCondition(dg1)));
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// ADT_A17 (Swap Patients) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-adt-a17-to-bundle.html
+// Segments: MSH, EVN, PID, PD1, PV1, PV2, OBX
+// --------------------------------------------------------------------------------------------#
+public isolated function adtA17ToBundle(hl7v23:ADT_A17 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // EVN → Provenance
+    entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // PID → Patient
+    entries.push(...populateBundleEntries(pidToPatient(message.pid)));
+    // PD1 → Patient (optional)
+    // PD1-7 → Observation (Living Will): IG dependsOn IF PD1-7 IS VALUED
+    hl7v23:PD1? pd1 = message.pd1;
+    if pd1 != () {
+        entries.push(...populateBundleEntries(pd1ToPatient(pd1)));
+        if pd1.pd17 != "" {
+            entries.push(...populateBundleEntries(pd1ToLivingWillObservation(pd1)));
+        }
+    }
+    // PV1 → Encounter + Patient
+    entries.push(...populateBundleEntries(pv1ToEncounter(message.pv1)));
+    entries.push(...populateBundleEntries(pv1ToPatient(message.pv1)));
+    // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+    if message.pv1.pv120[0].fc1 != "" {
+        entries.push(...populateBundleEntries(pv1ToCoverage(message.pv1)));
+    }
+    // PV2 → Encounter (optional)
+    hl7v23:PV2? pv2 = message.pv2;
+    if pv2 != () {
+        entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
+    }
+    // OBX → Observation
+    foreach hl7v23:OBX obx in message.obx {
+        entries.push(...populateBundleEntries(obxToObservation(obx)));
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// MDM_T02 (Original Document Notification with Content) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-mdm-t02-to-bundle.html
+// Segments: MSH, EVN, PID, PV1, TXA, OBX
+// --------------------------------------------------------------------------------------------#
+public isolated function mdmT02ToBundle(hl7v23:MDM_T02 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // EVN → Provenance
+    entries.push(...populateBundleEntries(evnToProvenance(message.evn)));
+    // PID → Patient
+    entries.push(...populateBundleEntries(pidToPatient(message.pid)));
+    // PV1 → Encounter + Patient
+    entries.push(...populateBundleEntries(pv1ToEncounter(message.pv1)));
+    entries.push(...populateBundleEntries(pv1ToPatient(message.pv1)));
+    // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+    if message.pv1.pv120[0].fc1 != "" {
+        entries.push(...populateBundleEntries(pv1ToCoverage(message.pv1)));
+    }
+    // TXA → DocumentReference
+    entries.push(...populateBundleEntries(txaToDocumentReference(message.txa)));
+    // TXA-8 → Provenance (edit history): IG dependsOn IF TXA-8 (Edit Date/Time) IS VALUED
+    if message.txa.txa8.length() > 0 && message.txa.txa8[0].ts1 != "" {
+        entries.push(...populateBundleEntries(txaToProvenance(message.txa)));
+    }
+    // OBX → Observation
+    foreach hl7v23:OBX obx in message.obx {
+        entries.push(...populateBundleEntries(obxToObservation(obx)));
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// ORM_O01 (General Order Message) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-orm-o01-to-bundle.html
+// Segments: MSH, NTE, PATIENT(PID,PD1,NTE,AL1,PATIENT_VISIT(PV1,PV2),INSURANCE(IN1,IN3)),
+//           ORDER(ORC, ORDER_DETAIL(NTE,DG1,ORDER_DETAIL_SEGMENT(OBR,RXO),OBSERVATION(OBX,NTE)))
+// --------------------------------------------------------------------------------------------#
+public isolated function ormO01ToBundle(hl7v23:ORM_O01 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // NTE[] → Observation (message-level notes)
+    foreach hl7v23:NTE nte in message.nte {
+        entries.push(...populateBundleEntries(nteToObservation(nte)));
+    }
+
+    // PATIENT group (optional)
+    hl7v23:ORM_O01_PATIENT? patient = message.patient;
+    if patient != () {
+        // PID → Patient
+        entries.push(...populateBundleEntries(pidToPatient(patient.pid)));
+        // PD1 → Patient (optional)
+        // PD1-7 → Observation (Living Will): IG dependsOn IF PD1-7 IS VALUED
+        hl7v23:PD1? pd1 = patient.pd1;
+        if pd1 != () {
+            entries.push(...populateBundleEntries(pd1ToPatient(pd1)));
+            if pd1.pd17 != "" {
+                entries.push(...populateBundleEntries(pd1ToLivingWillObservation(pd1)));
+            }
+        }
+        // NTE → Observation (patient-level notes)
+        foreach hl7v23:NTE nte in patient.nte {
+            entries.push(...populateBundleEntries(nteToObservation(nte)));
+        }
+        // AL1 → AllergyIntolerance
+        foreach hl7v23:AL1 al1 in patient.al1 {
+            entries.push(...populateBundleEntries(al1ToAllerygyIntolerance(al1)));
+        }
+        // PATIENT_VISIT sub-group (optional)
+        hl7v23:ORM_O01_PATIENT_VISIT? visit = patient.orm_o01_patient_visit;
+        if visit != () {
+            // PV1 → Encounter + Patient
+            entries.push(...populateBundleEntries(pv1ToEncounter(visit.pv1)));
+            entries.push(...populateBundleEntries(pv1ToPatient(visit.pv1)));
+            // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+            if visit.pv1.pv120[0].fc1 != "" {
+                entries.push(...populateBundleEntries(pv1ToCoverage(visit.pv1)));
+            }
+            // PV2 → Encounter (optional)
+            hl7v23:PV2? pv2 = visit.pv2;
+            if pv2 != () {
+                entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
+            }
+        }
+        // INSURANCE sub-groups → Coverage + CareTeam
+        foreach hl7v23:ORM_O01_INSURANCE ins in patient.orm_o01_insurance {
+            if ins.in1.in11 == "" {
+                continue;
+            }
+            entries.push(...populateBundleEntries(in1ToCoverage(ins.in1)));
+            hl7v23:IN3? in3 = ins.in3;
+            if in3 != () {
+                entries.push(...populateBundleEntries(in3ToCareTeam(in3)));
+            }
+        }
+    }
+
+    // ORDER groups
+    // Guard: orc1 (order control) is "" for Ballerina default empty instances
+    foreach hl7v23:ORM_O01_ORDER 'order in message.'order {
+        if 'order.orc.orc1 == "" {
+            continue;
+        }
+        // ORC → ServiceRequest
+        entries.push(...populateBundleEntries(orcToServiceRequest('order.orc)));
+
+        // ORDER_DETAIL sub-group (optional)
+        hl7v23:ORM_O01_ORDER_DETAIL? detail = 'order.orm_o01_order_detail;
+        if detail != () {
+            // NTE → Observation (order-level notes)
+            foreach hl7v23:NTE nte in detail.nte {
+                entries.push(...populateBundleEntries(nteToObservation(nte)));
+            }
+            // DG1 → Condition
+            foreach hl7v23:DG1 dg1 in detail.dg1 {
+                entries.push(...populateBundleEntries(dg1ToCondition(dg1)));
+            }
+            // ORDER_DETAIL_SEGMENT (choice: OBR or RXO)
+            // OBR → ServiceRequest (if PATIENT valued) / SupplyRequest (if PATIENT absent)
+            hl7v23:OBR? obr = detail.orm_o01_order_detail_segment.obr;
+            if obr != () {
+                if patient != () {
+                    // IG dependsOn: IF PID IS VALUED → ServiceRequest
+                    entries.push(...populateBundleEntries(obrToServiceRequest(obr)));
+                }
+                entries.push(...populateBundleEntries(obrToDiagnosticReport(obr)));
+            }
+            hl7v23:RXO? rxo = detail.orm_o01_order_detail_segment.rxo;
+            if rxo != () {
+                entries.push(...populateBundleEntries(rxoToMedicationRequest(rxo)));
+            }
+            // OBSERVATION sub-groups → Observation
+            // Guard: obx1 (set-ID) is "" for default empty instances
+            foreach hl7v23:ORM_O01_OBSERVATION obs in detail.orm_o01_observation {
+                if obs.obx.obx1 == "" {
+                    continue;
+                }
+                entries.push(...populateBundleEntries(obxToObservation(obs.obx)));
+                foreach hl7v23:NTE nte in obs.nte {
+                    entries.push(...populateBundleEntries(nteToObservation(nte)));
+                }
+            }
+        }
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// ORU_R01 (Unsolicited Observation Message) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-oru-r01-to-bundle.html
+// Note: ORU_R01 in HL7v23 exposes only MSH and DSC as typed fields; nested PATIENT_RESULT
+// groups (PID, PV1, OBR, OBX, NTE, ORC) are resolved dynamically by the HL7 parser at
+// runtime. This function handles the typed fields and delegates nested group processing to
+// the generic segment dispatcher. For programmatic access use v2ToFhir() which leverages
+// the full HL7 message entries() iteration including dynamic segment groups.
+// --------------------------------------------------------------------------------------------#
+public isolated function oruR01ToBundle(hl7v23:ORU_R01 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader (only statically-typed field in ORU_R01 besides DSC)
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+
+    // Nested PATIENT_RESULT groups (PID, PV1, OBR, OBX etc.) are stored as dynamic fields
+    // in the parsed ORU_R01 record and are not accessible via static field names.
+    // Use v2ToFhir() for complete ORU_R01 transformation including all nested groups.
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// SIU_S12 (Notification of New Appointment Booking) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-siu-s12-to-bundle.html
+// Segments: MSH, SCH, NTE, PATIENT(PID,PV1,PV2,OBX,DG1),
+//           RESOURCES(SERVICE(AIS,NTE), GENERAL_RESOURCE(AIG,NTE),
+//                     LOCATION_RESOURCE(AIL,NTE), PERSONNEL_RESOURCE(AIP,NTE))
+// --------------------------------------------------------------------------------------------#
+public isolated function siuS12ToBundle(hl7v23:SIU_S12 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // SCH → Appointment
+    entries.push(...populateBundleEntries(schToAppointment(message.sch)));
+    // NTE → Observation (message-level notes)
+    foreach hl7v23:NTE nte in message.nte {
+        entries.push(...populateBundleEntries(nteToObservation(nte)));
+    }
+
+    // PATIENT groups
+    // Guard: pid1 (set-ID) is "" for Ballerina default empty instances
+    foreach hl7v23:SIU_S12_PATIENT patient in message.patient {
+        if patient.pid.pid1 == "" {
+            continue;
+        }
+        // PID → Patient
+        entries.push(...populateBundleEntries(pidToPatient(patient.pid)));
+        // PV1 → Encounter + Patient (optional in SIU_S12)
+        hl7v23:PV1? pv1 = patient.pv1;
+        if pv1 != () {
+            entries.push(...populateBundleEntries(pv1ToEncounter(pv1)));
+            entries.push(...populateBundleEntries(pv1ToPatient(pv1)));
+            // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+            if pv1.pv120[0].fc1 != "" {
+                entries.push(...populateBundleEntries(pv1ToCoverage(pv1)));
+            }
+        }
+        // PV2 → Encounter (optional)
+        hl7v23:PV2? pv2 = patient.pv2;
+        if pv2 != () {
+            entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
+        }
+        // OBX → Observation
+        foreach hl7v23:OBX obx in patient.obx {
+            if obx.obx1 == "" {
+                continue;
+            }
+            entries.push(...populateBundleEntries(obxToObservation(obx)));
+        }
+        // DG1 → Condition
+        foreach hl7v23:DG1 dg1 in patient.dg1 {
+            if dg1.dg11 == "" {
+                continue;
+            }
+            entries.push(...populateBundleEntries(dg1ToCondition(dg1)));
+        }
+    }
+
+    // RESOURCES groups
+    foreach hl7v23:SIU_S12_RESOURCES resources in message.resources {
+        // SERVICE sub-groups → Appointment (AIS)
+        // Guard: ais1 (set-ID) is "" for Ballerina default empty instances
+        foreach hl7v23:SIU_S12_SERVICE svc in resources.siu_s12_service {
+            if svc.ais.ais1 == "" {
+                continue;
+            }
+            entries.push(...populateBundleEntries(aisToAppointment(svc.ais)));
+            foreach hl7v23:NTE nte in svc.nte {
+                entries.push(...populateBundleEntries(nteToObservation(nte)));
+            }
+        }
+        // GENERAL_RESOURCE sub-groups → Appointment (AIG)
+        foreach hl7v23:SIU_S12_GENERAL_RESOURCE gen in resources.siu_s12_general_resource {
+            if gen.aig.aig1 == "" {
+                continue;
+            }
+            entries.push(...populateBundleEntries(aigToAppointment(gen.aig)));
+            foreach hl7v23:NTE nte in gen.nte {
+                entries.push(...populateBundleEntries(nteToObservation(nte)));
+            }
+        }
+        // LOCATION_RESOURCE sub-groups → Appointment (AIL)
+        foreach hl7v23:SIU_S12_LOCATION_RESOURCE loc in resources.siu_s12_location_resource {
+            if loc.ail.ail1 == "" {
+                continue;
+            }
+            entries.push(...populateBundleEntries(ailToAppointment(loc.ail)));
+            foreach hl7v23:NTE nte in loc.nte {
+                entries.push(...populateBundleEntries(nteToObservation(nte)));
+            }
+        }
+        // PERSONNEL_RESOURCE sub-groups → Appointment (AIP)
+        foreach hl7v23:SIU_S12_PERSONNEL_RESOURCE per in resources.siu_s12_personnel_resource {
+            if per.aip.aip1 == "" {
+                continue;
+            }
+            entries.push(...populateBundleEntries(aipToAppointment(per.aip)));
+            foreach hl7v23:NTE nte in per.nte {
+                entries.push(...populateBundleEntries(nteToObservation(nte)));
+            }
+        }
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}
+
+// --------------------------------------------------------------------------------------------#
+// VXU_V04 (Unsolicited Vaccination Record Update) → Bundle
+// URL: https://build.fhir.org/ig/HL7/v2-to-fhir/branches/master/ConceptMap-message-vxu-v04-to-bundle.html
+// Segments: MSH, PID, PD1, NK1, PATIENT(PV1,PV2), INSURANCE(IN1,IN3),
+//           ORDER(ORC,RXA,RXR,OBSERVATION(OBX,NTE))
+// --------------------------------------------------------------------------------------------#
+public isolated function vxuV04ToBundle(hl7v23:VXU_V04 message) returns r4:Bundle|error {
+    r4:Bundle bundle = {'type: "transaction"};
+    r4:BundleEntry[] entries = [];
+
+    // MSH → MessageHeader
+    entries.push(...populateBundleEntries(mshToMessageHeader(message.msh)));
+    // PID → Patient
+    entries.push(...populateBundleEntries(pidToPatient(message.pid)));
+    // PD1 → Patient (optional)
+    // PD1-7 → Observation (Living Will): IG dependsOn IF PD1-7 IS VALUED
+    hl7v23:PD1? pd1 = message.pd1;
+    if pd1 != () {
+        entries.push(...populateBundleEntries(pd1ToPatient(pd1)));
+        if pd1.pd17 != "" {
+            entries.push(...populateBundleEntries(pd1ToLivingWillObservation(pd1)));
+        }
+    }
+    // NK1 → RelatedPerson + Patient
+    foreach hl7v23:NK1 nk1 in message.nk1 {
+        entries.push(...populateBundleEntries(nk1ToRelatedPerson(nk1)));
+        entries.push(...populateBundleEntries(nk1ToPatient(nk1)));
+    }
+
+    // PATIENT group (optional)
+    hl7v23:VXU_V04_PATIENT? patient = message.patient;
+    if patient != () {
+        // PV1 → Encounter + Patient
+        entries.push(...populateBundleEntries(pv1ToEncounter(patient.pv1)));
+        entries.push(...populateBundleEntries(pv1ToPatient(patient.pv1)));
+        // Coverage: IG dependsOn IF PV1-20 (Financial Class) IS VALUED
+        if patient.pv1.pv120[0].fc1 != "" {
+            entries.push(...populateBundleEntries(pv1ToCoverage(patient.pv1)));
+        }
+        // PV2 → Encounter (optional)
+        hl7v23:PV2? pv2 = patient.pv2;
+        if pv2 != () {
+            entries.push(...populateBundleEntries(pv2ToEncounter(pv2)));
+        }
+    }
+
+    // INSURANCE groups → Coverage + CareTeam
+    // Guard: in11 (set-ID) is "" for Ballerina default empty instances
+    foreach hl7v23:VXU_V04_INSURANCE ins in message.insurance {
+        if ins.in1.in11 == "" {
+            continue;
+        }
+        entries.push(...populateBundleEntries(in1ToCoverage(ins.in1)));
+        hl7v23:IN3? in3 = ins.in3;
+        if in3 != () {
+            entries.push(...populateBundleEntries(in3ToCareTeam(in3)));
+        }
+    }
+
+    // ORDER groups → Immunization + MedicationRequest + Observation
+    // Guard: rxa1 (set-ID / give sub-ID counter) is "" for Ballerina default empty instances
+    foreach hl7v23:VXU_V04_ORDER 'order in message.'order {
+        if 'order.rxa.rxa1 == "" {
+            continue;
+        }
+        // ORC → Immunization + ServiceRequest (optional)
+        hl7v23:ORC? orc = 'order.orc;
+        if orc != () {
+            entries.push(...populateBundleEntries(orcToImmunization(orc)));
+            entries.push(...populateBundleEntries(orcToServiceRequest(orc)));
+        }
+        // RXA → Immunization (required)
+        entries.push(...populateBundleEntries(rxaToImmunization('order.rxa)));
+        // RXR → Immunization + MedicationRequest (optional)
+        hl7v23:RXR? rxr = 'order.rxr;
+        if rxr != () {
+            entries.push(...populateBundleEntries(rxrToImmunization(rxr)));
+            entries.push(...populateBundleEntries(rxrToMedicationRequest(rxr)));
+        }
+        // OBSERVATION sub-groups → Observation
+        // Guard: obx1 (set-ID) is "" for default empty instances
+        foreach hl7v23:VXU_V04_OBSERVATION obs in 'order.vxu_v04_observation {
+            if obs.obx.obx1 == "" {
+                continue;
+            }
+            entries.push(...populateBundleEntries(obxToObservation(obs.obx)));
+            foreach hl7v23:NTE nte in obs.nte {
+                entries.push(...populateBundleEntries(nteToObservation(nte)));
+            }
+        }
+    }
+
+    bundle.entry = entries;
+    return bundle;
+}

--- a/utils/v23tofhirr4/tests/mapping_tests.bal
+++ b/utils/v23tofhirr4/tests/mapping_tests.bal
@@ -59,6 +59,8 @@ function hlStringMessageParseTest() {
 function v2toFhirTransformTest() {
     json|error adtToFhirBundle = v2ToFhir(msg);
     if adtToFhirBundle is json {
+        test:assertFalse(containsEmptyFields(adtToFhirBundle),
+            "Transformed bundle contains empty strings/objects/arrays");
         r4:Bundle|error resultantBundle = adtToFhirBundle.cloneWithType(r4:Bundle);
         if resultantBundle is r4:Bundle {
             r4:BundleEntry[] entries = resultantBundle.entry ?: [];
@@ -73,6 +75,37 @@ function v2toFhirTransformTest() {
     } else {
         test:assertFail("ADT_A01 msg to FHIR transforming failed.");
     }
+}
+
+function containsEmptyFields(json value) returns boolean {
+    if value is string {
+        return value == "";
+    }
+
+    if value is json[] {
+        if value.length() == 0 {
+            return true;
+        }
+        foreach json item in value {
+            if containsEmptyFields(item) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    if value is map<json> {
+        if value.keys().length() == 0 {
+            return true;
+        }
+        foreach string key in value.keys() {
+            if containsEmptyFields(value[key]) {
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 @test:Config {groups: ["g1"]}

--- a/utils/v23tofhirr4/tests/mapping_tests.bal
+++ b/utils/v23tofhirr4/tests/mapping_tests.bal
@@ -670,13 +670,30 @@ function adtA06ToBundleWithMrgTest() returns error? {
         evn: {name: "EVN", evn1: "A06"},
         pid: {name: "PID", pid5: [{xpn1: "Doe", xpn2: "John"}]},
         pv1: {name: "PV1", pv12: "I"},
-        mrg: {name: "MRG", mrg1: [{cx1: "OLD-001"}]}
+        mrg: {name: "MRG", mrg3: {cx1: "OLD-001"}}
     };
     r4:Bundle bundle = check adtA06ToBundle(message);
     test:assertEquals(bundle.'type, "transaction", "ADT_A06 should produce a transaction bundle");
     r4:BundleEntry[] entries = bundle.entry ?: [];
-    // Should include MRG → Account entry in addition to the base entries
-    test:assertTrue(entries.length() >= 4, "ADT_A06 with MRG should include Account entry");
+    boolean foundAccount = false;
+    foreach r4:BundleEntry entry in entries {
+        if entry?.'resource is map<anydata> {
+            map<anydata> mappedResource = <map<anydata>>entry?.'resource;
+            if mappedResource["resourceType"] == "Account" {
+                anydata identifiersValue = mappedResource["identifier"];
+                if identifiersValue is map<anydata>[] && identifiersValue.length() > 0 {
+                    map<anydata> identifier = identifiersValue[0];
+                    test:assertEquals(identifier["value"], "OLD-001",
+                        "ADT_A06 mrg.mrg3.cx1 should map to Account.identifier.value");
+                    foundAccount = true;
+                } else {
+                    test:assertFail("MRG should map to Account.identifier");
+                }
+                break;
+            }
+        }
+    }
+    test:assertTrue(foundAccount, "ADT_A06 bundle should contain an Account from MRG-3");
 }
 
 @test:Config {}

--- a/utils/v23tofhirr4/tests/mapping_tests.bal
+++ b/utils/v23tofhirr4/tests/mapping_tests.bal
@@ -62,9 +62,10 @@ function v2toFhirTransformTest() {
         r4:Bundle|error resultantBundle = adtToFhirBundle.cloneWithType(r4:Bundle);
         if resultantBundle is r4:Bundle {
             r4:BundleEntry[] entries = resultantBundle.entry ?: [];
-            // NK1 now maps to both Patient (contact) and RelatedPerson (+1)
-            // PV1 now maps to Patient, Encounter, and Coverage (+1)
-            test:assertEquals(entries.length(), 7, "Transforming issue occurred with the message");
+            // NK1 maps to both RelatedPerson and Patient (+2)
+            // PV1 maps to Encounter and Patient (Coverage omitted: PV1-20 not valued per IG dependsOn)
+            // MSH(1) + EVN(1) + PID(1) + NK1→RelatedPerson(1) + NK1→Patient(1) + PV1→Encounter(1) = 6
+            test:assertEquals(entries.length(), 6, "Transforming issue occurred with the message");
 
         } else {
             test:assertFail("ADT_A01 msg to FHIR transforming failed.");
@@ -559,4 +560,284 @@ function aisToAppointmentTest() {
     r4:CodeableConcept[] types = serviceType ?: [];
     r4:Coding[] codings = types[0].coding ?: [];
     test:assertEquals(codings[0].code, "CONSULT", "AIS-3 service code should be CONSULT");
+}
+
+// =============================================================================
+// Message-level mapping tests
+// =============================================================================
+
+@test:Config {}
+function adtA01ToBundleTest() returns error? {
+    hl7v23:ADT_A01 message = {
+        name: "ADT_A01",
+        msh: {name: "MSH", msh3: {hd1: "SENDER"}, msh4: {hd1: "FACILITY"}, msh9: {cm_msg1: "ADT", cm_msg2: "A01"}},
+        evn: {name: "EVN", evn1: "A01", evn2: {ts1: "20230101120000"}},
+        pid: {name: "PID", pid3: [{cx1: "P001"}], pid5: [{xpn1: "Smith", xpn2: "John"}], pid7: {ts1: "19800101"}},
+        pv1: {name: "PV1", pv12: "I", pv17: [{xcn1: "D001", xcn2: "Jones"}]}
+    };
+    r4:Bundle bundle = check adtA01ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "ADT_A01 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 3, "ADT_A01 should produce at least MessageHeader, Patient, and Encounter entries");
+}
+
+@test:Config {}
+function adtA01ToBundleWithNk1Test() returns error? {
+    hl7v23:ADT_A01 message = {
+        name: "ADT_A01",
+        msh: {name: "MSH", msh9: {cm_msg1: "ADT", cm_msg2: "A01"}},
+        evn: {name: "EVN", evn1: "A01"},
+        pid: {name: "PID", pid5: [{xpn1: "Doe", xpn2: "Jane"}]},
+        pv1: {name: "PV1", pv12: "O"},
+        nk1: [{name: "NK1", nk11: "1", nk12: [{xpn1: "Doe", xpn2: "John"}], nk13: {ce1: "SPO", ce2: "Spouse"}}]
+    };
+    r4:Bundle bundle = check adtA01ToBundle(message);
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    // NK1 should produce both RelatedPerson and Patient entries
+    test:assertTrue(entries.length() >= 5, "ADT_A01 with NK1 should include RelatedPerson and Patient from NK1");
+}
+
+@test:Config {}
+function adtA02ToBundleTest() returns error? {
+    hl7v23:ADT_A02 message = {
+        name: "ADT_A02",
+        msh: {name: "MSH", msh9: {cm_msg1: "ADT", cm_msg2: "A02"}},
+        evn: {name: "EVN", evn1: "A02"},
+        pid: {name: "PID", pid5: [{xpn1: "Doe", xpn2: "Jane"}]},
+        pv1: {name: "PV1", pv12: "I"}
+    };
+    r4:Bundle bundle = check adtA02ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "ADT_A02 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 3, "ADT_A02 should produce at least MessageHeader, Patient, and Encounter entries");
+}
+
+@test:Config {}
+function adtA05ToBundleTest() returns error? {
+    hl7v23:ADT_A05 message = {
+        name: "ADT_A05",
+        msh: {name: "MSH", msh9: {cm_msg1: "ADT", cm_msg2: "A05"}},
+        evn: {name: "EVN", evn1: "A05"},
+        pid: {name: "PID", pid5: [{xpn1: "Smith", xpn2: "Bob"}]},
+        pv1: {name: "PV1", pv12: "P"}
+    };
+    r4:Bundle bundle = check adtA05ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "ADT_A05 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 3, "ADT_A05 should produce at least MessageHeader, Patient, and Encounter entries");
+}
+
+@test:Config {}
+function adtA06ToBundleWithMrgTest() returns error? {
+    hl7v23:ADT_A06 message = {
+        name: "ADT_A06",
+        msh: {name: "MSH", msh9: {cm_msg1: "ADT", cm_msg2: "A06"}},
+        evn: {name: "EVN", evn1: "A06"},
+        pid: {name: "PID", pid5: [{xpn1: "Doe", xpn2: "John"}]},
+        pv1: {name: "PV1", pv12: "I"},
+        mrg: {name: "MRG", mrg1: [{cx1: "OLD-001"}]}
+    };
+    r4:Bundle bundle = check adtA06ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "ADT_A06 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    // Should include MRG → Account entry in addition to the base entries
+    test:assertTrue(entries.length() >= 4, "ADT_A06 with MRG should include Account entry");
+}
+
+@test:Config {}
+function adtA09ToBundleTest() returns error? {
+    hl7v23:ADT_A09 message = {
+        name: "ADT_A09",
+        msh: {name: "MSH", msh9: {cm_msg1: "ADT", cm_msg2: "A09"}},
+        evn: {name: "EVN", evn1: "A09"},
+        pid: {name: "PID", pid5: [{xpn1: "Lee", xpn2: "Chris"}]},
+        pv1: {name: "PV1", pv12: "E"}
+    };
+    r4:Bundle bundle = check adtA09ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "ADT_A09 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 3, "ADT_A09 should produce at least MessageHeader, Patient, and Encounter entries");
+}
+
+@test:Config {}
+function adtA11ToBundleTest() returns error? {
+    hl7v23:ADT_A11 message = {
+        name: "ADT_A11",
+        msh: {name: "MSH", msh9: {cm_msg1: "ADT", cm_msg2: "A11"}},
+        evn: {name: "EVN", evn1: "A11"},
+        pid: {name: "PID", pid5: [{xpn1: "Kim", xpn2: "Pat"}]},
+        pv1: {name: "PV1", pv12: "I"}
+    };
+    r4:Bundle bundle = check adtA11ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "ADT_A11 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 3, "ADT_A11 should produce at least MessageHeader, Patient, and Encounter entries");
+}
+
+@test:Config {}
+function adtA17ToBundleTest() returns error? {
+    hl7v23:ADT_A17 message = {
+        name: "ADT_A17",
+        msh: {name: "MSH", msh9: {cm_msg1: "ADT", cm_msg2: "A17"}},
+        evn: {name: "EVN", evn1: "A17"},
+        pid: {name: "PID", pid5: [{xpn1: "Park", xpn2: "Alex"}]},
+        pv1: {name: "PV1", pv12: "I"}
+    };
+    r4:Bundle bundle = check adtA17ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "ADT_A17 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 3, "ADT_A17 should produce at least MessageHeader, Patient, and Encounter entries");
+}
+
+@test:Config {}
+function mdmT02ToBundleTest() returns error? {
+    hl7v23:MDM_T02 message = {
+        name: "MDM_T02",
+        msh: {name: "MSH", msh9: {cm_msg1: "MDM", cm_msg2: "T02"}},
+        evn: {name: "EVN", evn1: "T02"},
+        pid: {name: "PID", pid5: [{xpn1: "Brown", xpn2: "Sara"}]},
+        pv1: {name: "PV1", pv12: "O"},
+        txa: {
+            name: "TXA",
+            txa1: "1",
+            txa2: "DS",
+            txa17: "AU"
+        }
+    };
+    r4:Bundle bundle = check mdmT02ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "MDM_T02 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 4, "MDM_T02 should include MessageHeader, Patient, Encounter, and DocumentReference");
+    // Verify DocumentReference is present
+    boolean hasDocRef = false;
+    foreach r4:BundleEntry entry in entries {
+        anydata res = entry?.'resource;
+        if res is international401:DocumentReference {
+            hasDocRef = true;
+        }
+    }
+    test:assertTrue(hasDocRef, "MDM_T02 should produce a DocumentReference from TXA segment");
+}
+
+@test:Config {}
+function ormO01ToBundleTest() returns error? {
+    hl7v23:ORM_O01 message = {
+        name: "ORM_O01",
+        msh: {name: "MSH", msh9: {cm_msg1: "ORM", cm_msg2: "O01"}},
+        patient: {
+            name: "ORM_O01_PATIENT",
+            isRequired: false,
+            pid: {name: "PID", pid5: [{xpn1: "Wilson", xpn2: "Tom"}]}
+        },
+        'order: [{
+            name: "ORM_O01_ORDER",
+            isRequired: true,
+            orc: {name: "ORC", orc1: "NW", orc2: {ei1: "ORD-001"}}
+        }]
+    };
+    r4:Bundle bundle = check ormO01ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "ORM_O01 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 2, "ORM_O01 should include at least MessageHeader and ServiceRequest");
+    // Verify ServiceRequest is present from ORC
+    boolean hasServiceRequest = false;
+    foreach r4:BundleEntry entry in entries {
+        anydata res = entry?.'resource;
+        if res is international401:ServiceRequest {
+            hasServiceRequest = true;
+        }
+    }
+    test:assertTrue(hasServiceRequest, "ORM_O01 should produce a ServiceRequest from ORC segment");
+}
+
+@test:Config {}
+function oruR01ToBundleTest() returns error? {
+    hl7v23:ORU_R01 message = {
+        name: "ORU_R01",
+        msh: {name: "MSH", msh9: {cm_msg1: "ORU", cm_msg2: "R01"}}
+    };
+    r4:Bundle bundle = check oruR01ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "ORU_R01 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 1, "ORU_R01 should include at least a MessageHeader entry");
+}
+
+@test:Config {}
+function siuS12ToBundleTest() returns error? {
+    hl7v23:SIU_S12 message = {
+        name: "SIU_S12",
+        msh: {name: "MSH", msh9: {cm_msg1: "SIU", cm_msg2: "S12"}},
+        sch: {
+            name: "SCH",
+            sch1: {ei1: "APT-001"},
+            sch6: {ce1: "ROUTINE"},
+            sch11: [{tq4: {ts1: "20230601090000"}}],
+            sch9: "20",
+            sch25: {ce1: "Booked"}
+        },
+        patient: [{
+            name: "SIU_S12_PATIENT",
+            isRequired: false,
+            pid: {name: "PID", pid5: [{xpn1: "Green", xpn2: "Amy"}]}
+        }],
+        resources: [{
+            name: "SIU_S12_RESOURCES",
+            isRequired: true,
+            rgs: {name: "RGS", rgs1: "1"},
+            siu_s12_service: [{
+                name: "SIU_S12_SERVICE",
+                isRequired: false,
+                ais: {name: "AIS", ais1: "1", ais2: "A", ais3: {ce1: "CONSULT"}}
+            }]
+        }]
+    };
+    r4:Bundle bundle = check siuS12ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "SIU_S12 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 2, "SIU_S12 should include at least MessageHeader and Appointment entries");
+    // Verify Appointment is present
+    boolean hasAppointment = false;
+    foreach r4:BundleEntry entry in entries {
+        anydata res = entry?.'resource;
+        if res is international401:Appointment {
+            hasAppointment = true;
+        }
+    }
+    test:assertTrue(hasAppointment, "SIU_S12 should produce an Appointment from SCH segment");
+}
+
+@test:Config {}
+function vxuV04ToBundleTest() returns error? {
+    hl7v23:VXU_V04 message = {
+        name: "VXU_V04",
+        msh: {name: "MSH", msh9: {cm_msg1: "VXU", cm_msg2: "V04"}},
+        pid: {name: "PID", pid5: [{xpn1: "White", xpn2: "Sam"}]},
+        'order: [{
+            name: "VXU_V04_ORDER",
+            isRequired: false,
+            rxa: {
+                name: "RXA",
+                rxa1: "0",
+                rxa2: "1",
+                rxa3: {ts1: "20230101"},
+                rxa4: {ts1: "20230101"},
+                rxa5: {ce1: "208", ce2: "Influenza Virus Vaccine", ce3: "CVX"},
+                rxa6: "0.5",
+                rxa7: {ce1: "mL"}
+            }
+        }]
+    };
+    r4:Bundle bundle = check vxuV04ToBundle(message);
+    test:assertEquals(bundle.'type, "transaction", "VXU_V04 should produce a transaction bundle");
+    r4:BundleEntry[] entries = bundle.entry ?: [];
+    test:assertTrue(entries.length() >= 2, "VXU_V04 should include at least MessageHeader and Immunization entries");
+    // Verify Immunization is present
+    boolean hasImmunization = false;
+    foreach r4:BundleEntry entry in entries {
+        anydata res = entry?.'resource;
+        if res is international401:Immunization {
+            hasImmunization = true;
+        }
+    }
+    test:assertTrue(hasImmunization, "VXU_V04 should produce an Immunization from RXA segment");
 }

--- a/utils/v23tofhirr4/tests/mapping_tests.bal
+++ b/utils/v23tofhirr4/tests/mapping_tests.bal
@@ -121,8 +121,8 @@ function v2toFhirTransformWithCustomService() {
         r4:Bundle|error resultantBundle = adtToFhirBundle.cloneWithType(r4:Bundle);
         if resultantBundle is r4:Bundle {
             r4:BundleEntry[] entries = resultantBundle.entry ?: [];
-            // NK1 is handled by custom service (1 entry), PV1 now also maps to Coverage (+1)
-            test:assertEquals(entries.length(), 6, "Transforming issue occurred with the message");
+            // NK1 is handled by custom service (1 entry), PV1-20 is empty so Coverage is omitted.
+            test:assertEquals(entries.length(), 5, "Transforming issue occurred with the message");
             r4:BundleEntry nk1MappedEntry = entries[3];
             map<anydata> patientResource = <map<anydata>>nk1MappedEntry?.'resource;
             test:assertEquals(patientResource["resourceType"], "Patient");
@@ -540,6 +540,8 @@ function aigToAppointmentTest() {
     test:assertEquals(appointment.status, "proposed", "AIG Appointment status should be proposed");
     test:assertTrue(appointment.participant.length() > 0, "AIG should map to participant");
     international401:AppointmentParticipant participant = appointment.participant[0];
+    r4:Reference actor = participant.actor ?: {};
+    test:assertEquals(actor.display, "Conference Room A", "AIG-3 should map to participant actor display");
     test:assertTrue(participant.'type != (), "AIG-4 resource type should map to participant type");
 }
 

--- a/utils/v23tofhirr4/tests/mapping_tests.bal
+++ b/utils/v23tofhirr4/tests/mapping_tests.bal
@@ -18,7 +18,9 @@ import ballerina/http;
 import ballerina/lang.runtime;
 import ballerina/test;
 import ballerinax/health.fhir.r4;
+import ballerinax/health.fhir.r4.international401;
 import ballerinax/health.hl7v2 as hl7;
+import ballerinax/health.hl7v23;
 
 final string msg = "MSH|^~\\&|ADT1|GOOD HEALTH HOSPITAL|GHH LAB, INC.|GOOD HEALTH HOSPITAL|" +
 "198808181126|SECURITY|ADT^A01^ADT_A01|MSG00001|P|2.3||\rEVN|A01|200708181123||" +
@@ -60,7 +62,9 @@ function v2toFhirTransformTest() {
         r4:Bundle|error resultantBundle = adtToFhirBundle.cloneWithType(r4:Bundle);
         if resultantBundle is r4:Bundle {
             r4:BundleEntry[] entries = resultantBundle.entry ?: [];
-            test:assertEquals(entries.length(), 5, "Transforming issue occurred with the message");
+            // NK1 now maps to both Patient (contact) and RelatedPerson (+1)
+            // PV1 now maps to Patient, Encounter, and Coverage (+1)
+            test:assertEquals(entries.length(), 7, "Transforming issue occurred with the message");
 
         } else {
             test:assertFail("ADT_A01 msg to FHIR transforming failed.");
@@ -83,7 +87,8 @@ function v2toFhirTransformWithCustomService() {
         r4:Bundle|error resultantBundle = adtToFhirBundle.cloneWithType(r4:Bundle);
         if resultantBundle is r4:Bundle {
             r4:BundleEntry[] entries = resultantBundle.entry ?: [];
-            test:assertEquals(entries.length(), 5, "Transforming issue occurred with the message");
+            // NK1 is handled by custom service (1 entry), PV1 now also maps to Coverage (+1)
+            test:assertEquals(entries.length(), 6, "Transforming issue occurred with the message");
             r4:BundleEntry nk1MappedEntry = entries[3];
             map<anydata> patientResource = <map<anydata>>nk1MappedEntry?.'resource;
             test:assertEquals(patientResource["resourceType"], "Patient");
@@ -160,3 +165,398 @@ http:Service customMapperService = service object {
         };
     }
 };
+
+// --------------------------------------------------------------------------------------------#
+// New segment mapping tests
+// --------------------------------------------------------------------------------------------#
+
+@test:Config {}
+function nk1ToRelatedPersonTest() {
+    hl7v23:NK1 nk1 = {
+        name: "NK1",
+        nk11: "1",
+        nk12: [{xpn1: "SMITH", xpn2: "JOHN", xpn5: "Dr."}],
+        nk13: {ce1: "SPO", ce2: "Spouse"},
+        nk14: [{xad1: "123 Main St", xad3: "Springfield", xad4: "IL", xad5: "62701"}],
+        nk15: [{xtn1: "555-123-4567", xtn2: "PRN"}],
+        nk115: "M",
+        nk116: {ts1: "19800601"}
+    };
+    international401:RelatedPerson relatedPerson = nk1ToRelatedPerson(nk1);
+    test:assertTrue(relatedPerson.name != (), "RelatedPerson should have name");
+    r4:HumanName[] names = relatedPerson.name ?: [];
+    test:assertEquals(names[0].family, "SMITH", "RelatedPerson family name should be SMITH");
+    test:assertTrue(relatedPerson.relationship != (), "RelatedPerson should have relationship");
+    test:assertEquals(relatedPerson.gender, "male", "RelatedPerson gender should be male");
+    test:assertEquals(relatedPerson.birthDate, "1980-06-01", "RelatedPerson birthDate should be mapped");
+}
+
+@test:Config {}
+function nteToObservationTest() {
+    hl7v23:NTE nte = {
+        name: "NTE",
+        nte1: "1",
+        nte2: "L",
+        nte3: ["Patient reports chest pain at rest"]
+    };
+    international401:Observation observation = nteToObservation(nte);
+    test:assertEquals(observation.status, "preliminary", "NTE Observation status should be preliminary");
+    r4:Annotation[] notes = observation.note ?: [];
+    test:assertTrue(notes.length() > 0, "NTE Observation should have notes");
+    test:assertEquals(notes[0].text, "Patient reports chest pain at rest", "NTE comment should be mapped to note text");
+}
+
+@test:Config {}
+function orcToServiceRequestTest() {
+    hl7v23:ORC orc = {
+        name: "ORC",
+        orc1: "NW",
+        orc2: {ei1: "PLACER-001"},
+        orc3: {ei1: "FILLER-001"},
+        orc12: [{xcn1: "DOC123", xcn2: "Smith", xcn3: "John"}]
+    };
+    international401:ServiceRequest serviceRequest = orcToServiceRequest(orc);
+    test:assertEquals(serviceRequest.intent, "order", "ORC ServiceRequest intent should be order");
+    test:assertEquals(serviceRequest.status, "unknown", "ORC ServiceRequest status should be unknown");
+    r4:Identifier[] identifiers = serviceRequest.identifier ?: [];
+    test:assertTrue(identifiers.length() >= 1, "ORC ServiceRequest should have identifiers");
+    test:assertEquals(identifiers[0].value, "PLACER-001", "Placer ID should be mapped");
+}
+
+@test:Config {}
+function obrToServiceRequestTest() {
+    hl7v23:OBR obr = {
+        name: "OBR",
+        obr3: {ei1: "FILLER-OBR-001"},
+        obr4: {ce1: "85025", ce2: "CBC with Differential", ce3: "LN"},
+        obr5: "R",
+        obr16: [{xcn1: "DOC456"}]
+    };
+    international401:ServiceRequest serviceRequest = obrToServiceRequest(obr);
+    test:assertTrue(serviceRequest.code != (), "OBR ServiceRequest should have code");
+    r4:CodeableConcept code = serviceRequest.code ?: {};
+    r4:Coding[] codings = code.coding ?: [];
+    test:assertTrue(codings.length() > 0, "OBR ServiceRequest code should have coding");
+    test:assertEquals(codings[0].code, "85025", "OBR-4 code should be mapped");
+}
+
+@test:Config {}
+function pr1ToProcedureTest() {
+    hl7v23:PR1 pr1 = {
+        name: "PR1",
+        pr11: "1",
+        pr13: {ce1: "80048", ce2: "Basic Metabolic Panel", ce3: "CPT"},
+        pr14: "Basic Metabolic Panel",
+        pr15: {ts1: "20230815"},
+        pr16: "D"
+    };
+    international401:Procedure procedure = pr1ToProcedure(pr1);
+    test:assertTrue(procedure.code != (), "PR1 Procedure should have code");
+    r4:CodeableConcept code = procedure.code ?: {};
+    r4:Coding[] codings = code.coding ?: [];
+    test:assertEquals(codings[0].code, "80048", "PR1-3 code should be mapped");
+    test:assertEquals(code.text, "Basic Metabolic Panel", "PR1-4 description should be mapped to code.text");
+    test:assertEquals(procedure.performedDateTime, "2023-08-15", "PR1-5 date should be mapped");
+    test:assertTrue(procedure.category != (), "PR1-6 should map to category");
+}
+
+@test:Config {}
+function rxaToImmunizationTest() {
+    hl7v23:RXA rxa = {
+        name: "RXA",
+        rxa1: "0",
+        rxa2: "1",
+        rxa3: {ts1: "20230901"},
+        rxa4: {},
+        rxa5: {ce1: "08", ce2: "Hepatitis B", ce3: "CVX"},
+        rxa6: "1",
+        rxa7: {ce1: "mL"},
+        rxa10: {xcn1: "NURSE001", xcn2: "Jones", xcn3: "Mary"},
+        rxa15: ["LOT12345"],
+        rxa20: "CP"
+    };
+    international401:Immunization immunization = rxaToImmunization(rxa);
+    test:assertEquals(immunization.status, "completed", "RXA Immunization status should be completed");
+    r4:CodeableConcept vaccineCode = immunization.vaccineCode;
+    r4:Coding[] codings = vaccineCode.coding ?: [];
+    test:assertEquals(codings[0].code, "08", "RXA-5 vaccine code should be mapped");
+    test:assertEquals(immunization.lotNumber, "LOT12345", "RXA-15 lot number should be mapped");
+    test:assertEquals(immunization.occurrenceDateTime, "2023-09-01", "RXA-3 occurrence date should be mapped");
+}
+
+@test:Config {}
+function rxoToMedicationRequestTest() {
+    hl7v23:RXO rxo = {
+        name: "RXO",
+        rxo1: {ce1: "ASPIRIN", ce2: "Aspirin 81mg"},
+        rxo2: "81",
+        rxo3: "162",
+        rxo4: {ce1: "mg"},
+        rxo13: "3",
+        rxo14: {xcn1: "PHYS001"}
+    };
+    international401:MedicationRequest medReq = rxoToMedicationRequest(rxo);
+    test:assertEquals(medReq.intent, "original-order", "RXO MedicationRequest intent should be original-order");
+    r4:CodeableConcept? medCode = medReq.medicationCodeableConcept;
+    test:assertTrue(medCode != (), "RXO MedicationRequest should have medication code");
+    test:assertTrue(medReq.dispenseRequest != (), "RXO dispense request should be mapped");
+}
+
+@test:Config {}
+function rxrToImmunizationTest() {
+    hl7v23:RXR rxr = {
+        name: "RXR",
+        rxr1: {ce1: "IM", ce2: "Intramuscular"},
+        rxr2: {ce1: "LA", ce2: "Left Arm"}
+    };
+    international401:Immunization immunization = rxrToImmunization(rxr);
+    test:assertTrue(immunization.route != (), "RXR-1 route should be mapped to Immunization.route");
+    r4:CodeableConcept route = immunization.route ?: {};
+    r4:Coding[] codings = route.coding ?: [];
+    test:assertEquals(codings[0].code, "IM", "RXR-1 route code should be IM");
+    test:assertTrue(immunization.site != (), "RXR-2 site should be mapped to Immunization.site");
+}
+
+@test:Config {}
+function rxrToMedicationRequestTest() {
+    hl7v23:RXR rxr = {
+        name: "RXR",
+        rxr1: {ce1: "PO", ce2: "Oral"},
+        rxr2: {},
+        rxr3: {},
+        rxr4: {ce1: "CHEW", ce2: "Chew"}
+    };
+    international401:MedicationRequest medReq = rxrToMedicationRequest(rxr);
+    r4:Dosage[] dosageInstructions = medReq.dosageInstruction ?: [];
+    test:assertTrue(dosageInstructions.length() > 0, "RXR should map to dosageInstruction");
+    r4:CodeableConcept? route = dosageInstructions[0].route;
+    test:assertTrue(route != (), "RXR-1 route should map to dosageInstruction.route");
+}
+
+@test:Config {}
+function schToAppointmentTest() {
+    hl7v23:SCH sch = {
+        name: "SCH",
+        sch1: {ei1: "APT-001"},
+        sch2: {ei1: "FILL-001"},
+        sch7: {ce1: "ROUTINE", ce2: "Routine"},
+        sch9: "30",
+        sch12: {xcn1: "DOC789", xcn2: "Brown", xcn3: "Carol"},
+        sch25: {ce1: "Complete"}
+    };
+    international401:Appointment appointment = schToAppointment(sch);
+    test:assertTrue(appointment.identifier != (), "SCH Appointment should have identifiers");
+    r4:Identifier[] ids = appointment.identifier ?: [];
+    test:assertEquals(ids[0].value, "APT-001", "SCH-1 placer ID should be mapped");
+    test:assertEquals(appointment.minutesDuration, 30, "SCH-9 duration should be mapped");
+    test:assertEquals(appointment.status, "fulfilled", "SCH-25 Complete should map to fulfilled");
+    test:assertTrue(appointment.participant.length() > 0, "SCH participants should be mapped");
+}
+
+@test:Config {}
+function txaToDocumentReferenceTest() {
+    hl7v23:TXA txa = {
+        name: "TXA",
+        txa1: "1",
+        txa2: "DS",
+        txa3: "TX",
+        txa6: {ts1: "20230901120000"},
+        txa9: {xcn1: "DOC001", xcn2: "Davis", xcn3: "Alan"},
+        txa12: {ei1: "DOC-2023-001"},
+        txa17: "AU",
+        txa19: "AV",
+        txa21: "Discharge Summary"
+    };
+    international401:DocumentReference docRef = txaToDocumentReference(txa);
+    test:assertTrue(docRef.'type != (), "TXA-2 document type should be mapped");
+    r4:CodeableConcept docType = docRef.'type ?: {};
+    r4:Coding[] typeCodings = docType.coding ?: [];
+    test:assertEquals(typeCodings[0].code, "DS", "TXA-2 document type code should be DS");
+    test:assertEquals(docRef.docStatus, "final", "TXA-17 AU should map to docStatus final");
+    test:assertEquals(docRef.status, "current", "TXA-19 AV should map to status current");
+    test:assertEquals(docRef.description, "Discharge Summary", "TXA-21 should map to description");
+    r4:Identifier? masterId = docRef.masterIdentifier;
+    test:assertTrue(masterId != (), "TXA-12 should map to masterIdentifier");
+    test:assertEquals(masterId?.value, "DOC-2023-001", "TXA-12 unique document ID should be mapped");
+}
+
+@test:Config {}
+function rolToRelatedPersonTest() {
+    hl7v23:ROL rol = {
+        name: "ROL",
+        rol1: {ei1: "ROLE-001"},
+        rol3: {ce1: "GUARD", ce2: "Guardian"},
+        rol4: {xcn1: "REL001", xcn2: "Wilson", xcn3: "Bob"},
+        rol5: {ts1: "20200101"},
+        rol6: {ts1: "20251231"}
+    };
+    international401:RelatedPerson relatedPerson = rolToRelatedPerson(rol);
+    test:assertTrue(relatedPerson.identifier != (), "ROL-1 should map to identifier");
+    test:assertTrue(relatedPerson.relationship != (), "ROL-3 should map to relationship");
+    r4:CodeableConcept[] rel = relatedPerson.relationship ?: [];
+    r4:Coding[] relCodings = rel[0].coding ?: [];
+    test:assertEquals(relCodings[0].code, "GUARD", "ROL-3 code should be GUARD");
+    test:assertTrue(relatedPerson.name != (), "ROL-4 should map to name");
+    r4:HumanName[] names = relatedPerson.name ?: [];
+    test:assertEquals(names[0].family, "Wilson", "ROL-4 family name should be Wilson");
+    test:assertTrue(relatedPerson.period != (), "ROL-5/6 should map to period");
+}
+
+@test:Config {}
+function msaToMessageHeaderTest() {
+    hl7v23:MSA msa = {
+        name: "MSA",
+        msa1: "AA",
+        msa2: "MSG00001",
+        msa3: "Message accepted"
+    };
+    international401:MessageHeader msgHeader = msaToMessageHeader(msa);
+    test:assertTrue(msgHeader.response != (), "MSA should produce a response in MessageHeader");
+    international401:MessageHeaderResponse resp = msgHeader.response ?: {identifier: "", code: "ok"};
+    test:assertEquals(resp.identifier, "MSG00001", "MSA-2 should map to response.identifier");
+    test:assertEquals(resp.code, "ok", "MSA-1 AA should map to response.code ok");
+}
+
+@test:Config {}
+function msaToMessageHeaderAeTest() {
+    hl7v23:MSA msa = {
+        name: "MSA",
+        msa1: "AE",
+        msa2: "MSG00002"
+    };
+    international401:MessageHeader msgHeader = msaToMessageHeader(msa);
+    international401:MessageHeaderResponse resp = msgHeader.response ?: {identifier: "", code: "ok"};
+    test:assertEquals(resp.code, "fatal-error", "MSA-1 AE should map to response.code fatal-error");
+}
+
+@test:Config {}
+function mrgToAccountTest() {
+    hl7v23:MRG mrg = {
+        name: "MRG",
+        mrg1: [{}],
+        mrg2: [{}],
+        mrg3: {cx1: "ACCT-12345", cx5: "AN"}
+    };
+    international401:Account account = mrgToAccount(mrg);
+    test:assertEquals(account.status, "unknown", "MRG Account status should be unknown");
+    r4:Identifier[] ids = account.identifier ?: [];
+    test:assertTrue(ids.length() > 0, "MRG-3 should map to Account identifier");
+    test:assertEquals(ids[0].value, "ACCT-12345", "MRG-3 account number should be mapped");
+}
+
+@test:Config {}
+function in1ToCoverageTest() {
+    hl7v23:IN1 in1 = {
+        name: "IN1",
+        in11: "1",
+        in12: {ce1: "PLAN-001", ce2: "Medicare"},
+        in14: [{xon1: "Medicare Insurance Co"}],
+        in112: "20200101",
+        in113: "20251231",
+        in115: "Medicare",
+        in117: "SE"
+    };
+    international401:Coverage coverage = in1ToCoverage(in1);
+    test:assertEquals(coverage.status, "active", "IN1 Coverage status should be active");
+    r4:Reference[] payors = coverage.payor;
+    test:assertTrue(payors.length() > 0 && payors[0].display != (), "IN1-4 payor name should be mapped");
+    test:assertEquals(payors[0].display, "Medicare Insurance Co", "IN1-4 payor should be mapped");
+    test:assertTrue(coverage.period != (), "IN1-12/13 should map to period");
+    test:assertTrue(coverage.'type != (), "IN1-15 plan type should be mapped");
+    test:assertTrue(coverage.relationship != (), "IN1-17 relationship should be mapped");
+}
+
+@test:Config {}
+function in3ToCareTeamTest() {
+    hl7v23:IN3 in3 = {
+        name: "IN3",
+        in31: "1",
+        in321: "Dr. Jane Smith"
+    };
+    international401:CareTeam careTeam = in3ToCareTeam(in3);
+    test:assertTrue(careTeam.participant != (), "IN3-21 case manager should map to CareTeam participant");
+}
+
+@test:Config {}
+function pv1ToCoverageTest() {
+    hl7v23:PV1 pv1 = {
+        name: "PV1",
+        pv12: "I",
+        pv120: [{fc1: "BC", fc2: {ts1: "20230101"}}]
+    };
+    international401:Coverage coverage = pv1ToCoverage(pv1);
+    test:assertEquals(coverage.status, "active", "PV1 Coverage should be active");
+    test:assertTrue(coverage.'type != (), "PV1-20 financial class should map to Coverage.type");
+    r4:CodeableConcept covType = coverage.'type ?: {};
+    r4:Coding[] codings = covType.coding ?: [];
+    test:assertEquals(codings[0].code, "BC", "PV1-20 FC1 should be mapped as Coverage type code");
+}
+
+@test:Config {}
+function aigToAppointmentTest() {
+    hl7v23:AIG aig = {
+        name: "AIG",
+        aig1: "1",
+        aig2: "A",
+        aig3: {ce1: "RES-001", ce2: "Conference Room A"},
+        aig4: {ce1: "ROOM", ce2: "Room"},
+        aig8: {ts1: "20230901090000"}
+    };
+    international401:Appointment appointment = aigToAppointment(aig);
+    test:assertEquals(appointment.status, "proposed", "AIG Appointment status should be proposed");
+    test:assertTrue(appointment.participant.length() > 0, "AIG should map to participant");
+    international401:AppointmentParticipant participant = appointment.participant[0];
+    test:assertTrue(participant.'type != (), "AIG-4 resource type should map to participant type");
+}
+
+@test:Config {}
+function ailToAppointmentTest() {
+    hl7v23:AIL ail = {
+        name: "AIL",
+        ail1: "1",
+        ail2: "A",
+        ail3: {pl1: "EXAM-ROOM-2"},
+        ail6: {ts1: "20230901100000"}
+    };
+    international401:Appointment appointment = ailToAppointment(ail);
+    test:assertEquals(appointment.status, "proposed", "AIL Appointment status should be proposed");
+    international401:AppointmentParticipant participant = appointment.participant[0];
+    test:assertTrue(participant.actor != (), "AIL-3 location should map to actor");
+    r4:Reference actor = participant.actor ?: {};
+    test:assertEquals(actor.display, "EXAM-ROOM-2", "AIL-3 location ID should be mapped");
+}
+
+@test:Config {}
+function aipToAppointmentTest() {
+    hl7v23:AIP aip = {
+        name: "AIP",
+        aip1: "1",
+        aip2: "A",
+        aip3: {xcn1: "PRACT001", xcn2: "Taylor", xcn3: "Emma"},
+        aip4: {ce1: "PHYS", ce2: "Physician"},
+        aip6: {ts1: "20230901090000"},
+        aip12: {ce1: "Accepted"}
+    };
+    international401:Appointment appointment = aipToAppointment(aip);
+    international401:AppointmentParticipant participant = appointment.participant[0];
+    test:assertTrue(participant.actor != (), "AIP-3 personnel should map to actor");
+    test:assertEquals(participant.status, "accepted", "AIP-12 Accepted should map to status accepted");
+}
+
+@test:Config {}
+function aisToAppointmentTest() {
+    hl7v23:AIS ais = {
+        name: "AIS",
+        ais1: "1",
+        ais2: "A",
+        ais3: {ce1: "CONSULT", ce2: "Consultation"},
+        ais10: {ce1: "Complete"}
+    };
+    international401:Appointment appointment = aisToAppointment(ais);
+    test:assertEquals(appointment.status, "fulfilled", "AIS-10 Complete should map to fulfilled status");
+    r4:CodeableConcept[]? serviceType = appointment.serviceType;
+    test:assertTrue(serviceType != (), "AIS-3 should map to serviceType");
+    r4:CodeableConcept[] types = serviceType ?: [];
+    r4:Coding[] codings = types[0].coding ?: [];
+    test:assertEquals(codings[0].code, "CONSULT", "AIS-3 service code should be CONSULT");
+}

--- a/utils/v23tofhirr4/tests/mapping_tests.bal
+++ b/utils/v23tofhirr4/tests/mapping_tests.bal
@@ -62,10 +62,10 @@ function v2toFhirTransformTest() {
         r4:Bundle|error resultantBundle = adtToFhirBundle.cloneWithType(r4:Bundle);
         if resultantBundle is r4:Bundle {
             r4:BundleEntry[] entries = resultantBundle.entry ?: [];
-            // NK1 maps to both RelatedPerson and Patient (+2)
-            // PV1 maps to Encounter and Patient (Coverage omitted: PV1-20 not valued per IG dependsOn)
-            // MSH(1) + EVN(1) + PID(1) + NK1→RelatedPerson(1) + NK1→Patient(1) + PV1→Encounter(1) = 6
-            test:assertEquals(entries.length(), 6, "Transforming issue occurred with the message");
+            // MSH(1) + EVN→Provenance(1) + MSH→Provenance-Operator(1) [EVN-5 empty, MSH-4 valued]
+            // + PID(1) + NK1→RelatedPerson(1) + NK1→Patient(1) + PV1→Encounter(1) = 7
+            // PV1-20 not valued → Coverage omitted (IG dependsOn condition)
+            test:assertEquals(entries.length(), 7, "Transforming issue occurred with the message");
 
         } else {
             test:assertFail("ADT_A01 msg to FHIR transforming failed.");

--- a/utils/v23tofhirr4/type_defs.bal
+++ b/utils/v23tofhirr4/type_defs.bal
@@ -153,3 +153,57 @@ public type Nk131 hl7v23:XTN[];
 # Union type for patient's extended person's contact person address for all supported hl7 versions.
 
 public type Nk132 hl7v23:XAD[];
+
+# Union type for holding notes and comments segment for all supported hl7 versions.
+public type Nte hl7v23:NTE;
+
+# Union type for holding procedure segment for all supported hl7 versions.
+public type Pr1 hl7v23:PR1;
+
+# Union type for holding role segment for all supported hl7 versions.
+public type Rol hl7v23:ROL;
+
+# Union type for holding pharmacy/treatment administration segment for all supported hl7 versions.
+public type Rxa hl7v23:RXA;
+
+# Union type for holding pharmacy/treatment order segment for all supported hl7 versions.
+public type Rxo hl7v23:RXO;
+
+# Union type for holding pharmacy/treatment route segment for all supported hl7 versions.
+public type Rxr hl7v23:RXR;
+
+# Union type for holding schedule activity information segment for all supported hl7 versions.
+public type Sch hl7v23:SCH;
+
+# Union type for holding transcription document header segment for all supported hl7 versions.
+public type Txa hl7v23:TXA;
+
+# Union type for holding insurance segment for all supported hl7 versions.
+public type In1 hl7v23:IN1;
+
+# Union type for holding insurance additional info - certification segment for all supported hl7 versions.
+public type In3 hl7v23:IN3;
+
+# Union type for holding merge patient information segment for all supported hl7 versions.
+public type Mrg hl7v23:MRG;
+
+# Union type for holding message acknowledgement segment for all supported hl7 versions.
+public type Msa hl7v23:MSA;
+
+# Union type for holding appointment information - general resource segment for all supported hl7 versions.
+public type Aig hl7v23:AIG;
+
+# Union type for holding appointment information - location resource segment for all supported hl7 versions.
+public type Ail hl7v23:AIL;
+
+# Union type for holding appointment information - personnel resource segment for all supported hl7 versions.
+public type Aip hl7v23:AIP;
+
+# Union type for holding appointment information - service segment for all supported hl7 versions.
+public type Ais hl7v23:AIS;
+
+# Union type for CX (composite ID with check digit) data type for all supported hl7 versions.
+public type Cx hl7v23:CX;
+
+# Union type for PL (person location) data type for all supported hl7 versions.
+public type Pl hl7v23:PL;

--- a/utils/v23tofhirr4/utilities.bal
+++ b/utils/v23tofhirr4/utilities.bal
@@ -264,7 +264,8 @@ public isolated function nk1ToContact(Nk12 nk12, Nk14 nk14, Nk15 nk15, Nk16 nk16
 
 isolated function isTransactionalMessage(hl7:Message message) returns boolean {
     return message.name.startsWith("ADT") || message.name.startsWith("ORM") || message.name.startsWith("ORU") ||
-        message.name.startsWith("SIU") || message.name.startsWith("MDM") || message.name.startsWith("RDE");
+        message.name.startsWith("SIU") || message.name.startsWith("MDM") || message.name.startsWith("RDE") ||
+        message.name.startsWith("VXU");
 }
 
 isolated function transformToFhir(hl7:Message message, V2SegmentToFhirMapper? customMapper, V2ToFhirCustomMapperServiceConfig? mapperServiceConf) returns json|error {

--- a/utils/v23tofhirr4/utilities.bal
+++ b/utils/v23tofhirr4/utilities.bal
@@ -46,21 +46,17 @@ public isolated function pidToAdministrativeSex(string pid8) returns internation
 
 public isolated function pidToPatientName(Pid5 pid5, Pid9 pid9) returns r4:HumanName[]? {
     r4:HumanName[] humanNames = [];
-    if pid5 is hl7v23:XPN[] {
-        foreach hl7v23:XPN item in pid5 {
-            r4:HumanName name = xpnToHumanName(item);
-            if name != {} {
-                humanNames.push(name);
-            }
+    foreach hl7v23:XPN item in pid5 {
+        r4:HumanName name = xpnToHumanName(item);
+        if name != {} {
+            humanNames.push(name);
         }
     }
 
-    if pid9 is hl7v23:XPN[] {
-        foreach hl7v23:XPN item in pid9 {
-            r4:HumanName name = xpnToHumanName(item);
-            if name != {} {
-                humanNames.push(name);
-            }
+    foreach hl7v23:XPN item in pid9 {
+        r4:HumanName name = xpnToHumanName(item);
+        if name != {} {
+            humanNames.push(name);
         }
     }
 
@@ -73,12 +69,10 @@ public isolated function pidToAddress(string pid12, Pid11 pid11) returns r4:Addr
         address.push({district: pid12});
     }
 
-    if pid11 is hl7v23:XAD[] {
-        foreach hl7v23:XAD item in pid11 {
-            r4:Address? xadToAddressResult = xadToAddress(item);
-            if xadToAddressResult is r4:Address {
-                address.push(xadToAddressResult);
-            }
+    foreach hl7v23:XAD item in pid11 {
+        r4:Address? xadToAddressResult = xadToAddress(item);
+        if xadToAddressResult is r4:Address {
+            address.push(xadToAddressResult);
         }
     }
     return (address.length() > 0) ? address : ();
@@ -88,21 +82,17 @@ public isolated function pidToPhoneNumber(Pid13 pid13, Pid14 pid14) returns r4:C
     r4:ContactPoint[] phoneNumbers = [];
 
     //get ContactPointFromXTN use this
-    if pid13 is hl7v23:XTN[] {
-        foreach hl7v23:XTN item in pid13 {
-            r4:ContactPoint? contactPoint = xtnToContactPoint(item);
-            if contactPoint != () {
-                phoneNumbers.push(contactPoint);
-            }
+    foreach hl7v23:XTN item in pid13 {
+        r4:ContactPoint? contactPoint = xtnToContactPoint(item);
+        if contactPoint != () {
+            phoneNumbers.push(contactPoint);
         }
     }
 
-    if pid14 is hl7v23:XTN[] {
-        foreach hl7v23:XTN item in pid14 {
-            r4:ContactPoint? contactPoint = xtnToContactPoint(item);
-            if contactPoint != () {
-                phoneNumbers.push(contactPoint);
-            }
+    foreach hl7v23:XTN item in pid14 {
+        r4:ContactPoint? contactPoint = xtnToContactPoint(item);
+        if contactPoint != () {
+            phoneNumbers.push(contactPoint);
         }
     }
 
@@ -110,10 +100,8 @@ public isolated function pidToPhoneNumber(Pid13 pid13, Pid14 pid14) returns r4:C
 }
 
 public isolated function pidToPrimaryLanguage(Pid15 pid15) returns international401:PatientCommunication[]? {
-    if pid15 is hl7v23:CE {
-        r4:CodeableConcept ceToCodeableConceptResult = ceToCodeableConcept(pid15);
-        return ceToCodeableConceptResult != {} ? [{language: ceToCodeableConceptResult}] : ();
-    }
+    r4:CodeableConcept ceToCodeableConceptResult = ceToCodeableConcept(pid15);
+    return ceToCodeableConceptResult != {} ? [{language: ceToCodeableConceptResult}] : ();
 }
 
 public isolated function pidToMaritalStatus(Pid16 pid16) returns r4:CodeableConcept? {
@@ -122,7 +110,7 @@ public isolated function pidToMaritalStatus(Pid16 pid16) returns r4:CodeableConc
         if pid16.ce1 != "" {
             maritialStatues.push({code: pid16.ce1});
         }
-    } else if pid16 is string && pid16 != "" {
+    } else if pid16 != "" {
         maritialStatues.push({code: pid16});
     }
     return (maritialStatues.length() > 0) ? {coding: maritialStatues} : ();

--- a/utils/v23tofhirr4/utilities.bal
+++ b/utils/v23tofhirr4/utilities.bal
@@ -245,12 +245,18 @@ public isolated function nk1ToContact(Nk12 nk12, Nk14 nk14, Nk15 nk15, Nk16 nk16
         }
     }
 
-    patientContact.telecom = telecoms;
+    if telecoms.length() > 0 {
+        patientContact.telecom = telecoms;
+    }
 
     r4:CodeableConcept[] relationship = [];
     r4:CodeableConcept relation = ceToCodeableConcept(nk17);
-    relationship.push(relation);
-    patientContact.relationship = relationship;
+    if relation != {} {
+        relationship.push(relation);
+    }
+    if relationship.length() > 0 {
+        patientContact.relationship = relationship;
+    }
 
     r4:Period period = {'start: nk18 != "" ? nk18 : (), end: (nk19 != "") ? nk19 : ()};
     if period != {} {
@@ -259,7 +265,7 @@ public isolated function nk1ToContact(Nk12 nk12, Nk14 nk14, Nk15 nk15, Nk16 nk16
 
     patientContact.gender = pidToAdministrativeSex(nk115);
 
-    return [patientContact];
+    return patientContact != {} ? [patientContact] : [];
 }
 
 isolated function isTransactionalMessage(hl7:Message message) returns boolean {


### PR DESCRIPTION
## Purpose
> This PR will add following to the v2tofhir lib:
> - Message specific mappings supported by the IG
> - Fix mappings as per the latest mapping guide changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the v2tofhir (HL7 v2.3 → FHIR R4) mapping library to add message-specific mappings, correct and extend segment-level mappings to match the Implementation Guide (IG), simplify mapping logic, and update dependencies and tests.

Key changes
- Message-level bundle mappings
  - Added typed message-to-Bundle transformations for ADT_A01, ADT_A02, ADT_A05, ADT_A06, ADT_A09, ADT_A11, ADT_A17, MDM_T02, ORM_O01, SIU_S12, and VXU_V04. Each builds a transaction Bundle by aggregating mapped resources.
  - v2ToFhir now attempts message-specific mapping first and falls back to segment-level mapping when no typed mapper is available.

- Expanded segment and type coverage
  - Added many new mapping functions and public mapping types to cover additional HL7 v2.3 segments (NK1, NTE, ORC, OBR, PR1, RXA, RXO, RXR, SCH, TXA, ROL, MSA, MRG, IN1, IN3, PV1 coverage handling, appointment-related segments AIG/AIL/AIP/AIS, and more) and new target FHIR resources (RelatedPerson, Observation, ServiceRequest, Procedure, Immunization, MedicationRequest, Appointment, DocumentReference, MessageHeader, Account, Coverage, CareTeam, etc.).
  - Introduced exported type aliases for the added HL7 v2 segments and data types.

- Mapping logic simplification and enhancements
  - Removed many redundant runtime type-guards and moved to field-driven logic for more consistent outputs.
  - Added utility mapping helpers (e.g., cxToIdentifier, xcnToHumanName, xcnToReferenceWithName, getHdEndpoint) and improved several datatype mappers to produce richer codings, extensions, and multiple FHIR entries where appropriate.
  - Adjusted behavior of numerous segment mappers (e.g., OBX, OBR, ORC, PV1, NK1) to emit additional or differently structured resources aligned with the IG.

- Dependency and manifest updates
  - Bumped versions for several Ballerina and ballerinax packages and added a new ballerina.data.csv dependency; updated package dependency lists in utils/v23tofhirr4/Dependencies.toml.

- Tests
  - Added extensive unit tests for the new segment mappings and message-level Bundle transformations.
  - Strengthened existing tests (e.g., ADT_A01) to assert increased bundle entries and to fail when transformed Bundles contain empty fields.

Intent and impact
- Improves mapping completeness and alignment with the HL7 v2.3 → FHIR R4 Implementation Guide, enabling richer, message-aware Bundle construction.
- Simplifies mapper logic for maintainability and more predictable field handling.
- Expands test coverage to validate the new and corrected mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->