### PR TITLE
Fix issues with segment group naming, compatible with other versions

### DIFF
--- a/hl7v22/Dependencies.toml
+++ b/hl7v22/Dependencies.toml
@@ -132,7 +132,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "health.hl7v2"
-version = "3.0.9"
+version = "3.0.10"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"},

--- a/hl7v22/message_adr_a19.bal
+++ b/hl7v22/message_adr_a19.bal
@@ -295,6 +295,6 @@ public type ADR_A19 record {
     MSA msa = {};
     ERR err?;
     QRD qrd = {};
-    ADR_A19_QUERY_RESPONSE[] query_response = [{pid: {}}];
+    ADR_A19_QUERY_RESPONSE[] query_response = [{pid: {}, pv1: {}}];
     DSC dsc?;
 };

--- a/hl7v22/message_orf_r04.bal
+++ b/hl7v22/message_orf_r04.bal
@@ -188,6 +188,6 @@ public type ORF_R04 record {
     string name = ORF_R04_MESSAGE_TYPE;
     MSH msh = {};
     MSA msa = {};
-    ORF_R04_QUERY_RESPONSE[] query_response = [{qrd: {}}];
+    ORF_R04_QUERY_RESPONSE[] query_response = [{qrd: {}, orf_r04_order: [{obr: {}}]}];
     DSC dsc?;
 };

--- a/hl7v22/message_oru_r01.bal
+++ b/hl7v22/message_oru_r01.bal
@@ -172,6 +172,6 @@ public type ORU_R01 record {
     *hl7v2:Message;
     string name = ORU_R01_MESSAGE_TYPE;
     MSH msh = {};
-    ORU_R01_PATIENT_RESULT[] patient_result = [{}];
+    ORU_R01_PATIENT_RESULT[] patient_result = [{oru_r01_order_observation: [{obr: {}}]}];
     DSC dsc?;
 };

--- a/hl7v22/message_rar_rar.bal
+++ b/hl7v22/message_rar_rar.bal
@@ -207,6 +207,6 @@ public type RAR_RAR record {
     MSH msh = {};
     MSA msa = {};
     ERR err?;
-    RAR_RAR_DEFINITION[] definition = [{qrd: {}}];
+    RAR_RAR_DEFINITION[] definition = [{qrd: {}, rar_rar_order: [{orc: {}, rxa: [{}]}]}];
     DSC dsc?;
 };

--- a/hl7v22/message_ras_o02.bal
+++ b/hl7v22/message_ras_o02.bal
@@ -300,5 +300,5 @@ public type RAS_O02 record {
     MSH msh = {};
     NTE[] nte = [];
     RAS_O02_PATIENT patient?;
-    RAS_O02_ORDER[] 'order = [{orc: {}}];
+    RAS_O02_ORDER[] 'order = [{orc: {}, rxa: [{}], rxr: {}}];
 };

--- a/hl7v22/message_rde_o01.bal
+++ b/hl7v22/message_rde_o01.bal
@@ -264,5 +264,5 @@ public type RDE_O01 record {
     MSH msh = {};
     NTE[] nte = [];
     RDE_O01_PATIENT patient?;
-    RDE_O01_ORDER[] 'order = [{orc: {}}];
+    RDE_O01_ORDER[] 'order = [{orc: {}, rxe: {}, rxr: [{}]}];
 };

--- a/hl7v22/message_rdr_rdr.bal
+++ b/hl7v22/message_rdr_rdr.bal
@@ -224,6 +224,6 @@ public type RDR_RDR record {
     MSH msh = {};
     MSA msa = {};
     ERR err?;
-    RDR_RDR_DEFINITION[] definition = [{qrd: {}}];
+    RDR_RDR_DEFINITION[] definition = [{qrd: {}, rdr_rdr_order: [{orc: {}, rdr_rdr_dispense: [{rxd: {}, rxr: [{}]}]}]}];
     DSC dsc?;
 };

--- a/hl7v22/message_rds_o01.bal
+++ b/hl7v22/message_rds_o01.bal
@@ -311,5 +311,5 @@ public type RDS_O01 record {
     MSH msh = {};
     NTE[] nte = [];
     RDS_O01_PATIENT patient?;
-    RDS_O01_ORDER[] 'order = [{orc: {}}];
+    RDS_O01_ORDER[] 'order = [{orc: {}, rxd: {}, rxr: [{}]}];
 };

--- a/hl7v22/message_rer_rer.bal
+++ b/hl7v22/message_rer_rer.bal
@@ -188,6 +188,6 @@ public type RER_RER record {
     MSH msh = {};
     MSA msa = {};
     ERR err?;
-    RER_RER_DEFINITION[] definition = [{qrd: {}}];
+    RER_RER_DEFINITION[] definition = [{qrd: {}, rer_rer_order: [{orc: {}, rxe: {}, rxr: [{}]}]}];
     DSC dsc?;
 };

--- a/hl7v22/message_rgr_rgr.bal
+++ b/hl7v22/message_rgr_rgr.bal
@@ -218,6 +218,6 @@ public type RGR_RGR record {
     MSH msh = {};
     MSA msa = {};
     ERR err?;
-    RGR_RGR_DEFINITION[] definition = [{qrd: {}}];
+    RGR_RGR_DEFINITION[] definition = [{qrd: {}, rgr_rgr_order: [{orc: {}, rxg: [{}], rxr: [{}]}]}];
     DSC dsc?;
 };

--- a/hl7v22/message_rgv_o01.bal
+++ b/hl7v22/message_rgv_o01.bal
@@ -317,5 +317,5 @@ public type RGV_O01 record {
     MSH msh = {};
     NTE[] nte = [];
     RGV_O01_PATIENT patient?;
-    RGV_O01_ORDER[] 'order = [{orc: {}}];
+    RGV_O01_ORDER[] 'order = [{orc: {}, rgv_o01_give: {rxg: {}, rxr: [{}]}}];
 };

--- a/hl7v22/message_ror_ror.bal
+++ b/hl7v22/message_ror_ror.bal
@@ -188,6 +188,6 @@ public type ROR_ROR record {
     MSH msh = {};
     MSA msa = {};
     ERR err?;
-    ROR_ROR_DEFINITION[] definition = [{qrd: {}}];
+    ROR_ROR_DEFINITION[] definition = [{qrd: {}, ror_ror_order: [{orc: {}, rxo: {}, rxr: [{}]}]}];
     DSC dsc?;
 };

--- a/hl7v22/segment_component_adr_a19_query_response.bal
+++ b/hl7v22/segment_component_adr_a19_query_response.bal
@@ -34,7 +34,7 @@ public type ADR_A19_QUERY_RESPONSE record {
     DG1[] dg1 = [];
     PR1[] pr1 = [];
     GT1[] gt1 = [];
-    ADR_A19_INSURANCE[] insurance = [];
+    ADR_A19_INSURANCE[] adr_a19_insurance = [];
     ACC acc?;
     UB1 ub1?;
     UB2 ub2?;

--- a/hl7v22/segment_component_bar_p01_visit.bal
+++ b/hl7v22/segment_component_bar_p01_visit.bal
@@ -32,7 +32,7 @@ public type BAR_P01_VISIT record {
     PR1[] pr1 = [];
     GT1[] gt1 = [];
     NK1[] nk1 = [];
-    BAR_P01_INSURANCE[] insurance = [];
+    BAR_P01_INSURANCE[] bar_p01_insurance = [];
     ACC acc?;
     UB1 ub1?;
     UB2 ub2?;

--- a/hl7v22/segment_component_nmd_n01_app_stats.bal
+++ b/hl7v22/segment_component_nmd_n01_app_stats.bal
@@ -26,7 +26,7 @@ public type NMD_N01_APP_STATS record {
     boolean isRequired = false;
     NST nst = {};
     NTE[] nte = [];
-    NMD_N01_APP_STATUS app_status = {nsc: {}};
+    NMD_N01_APP_STATUS nmd_n01_app_status?;
 };
 
 public const NMD_N01_APP_STATS_SEGMENT_COMPONENT = "NMD_N01_APP_STATS";

--- a/hl7v22/segment_component_nmd_n01_clock.bal
+++ b/hl7v22/segment_component_nmd_n01_clock.bal
@@ -26,7 +26,7 @@ public type NMD_N01_CLOCK record {
     boolean isRequired = false;
     NCK nck = {};
     NTE[] nte = [];
-    NMD_N01_APP_STATS app_stats = {nst: {}};
+    NMD_N01_APP_STATS nmd_n01_app_stats?;
 };
 
 public const NMD_N01_CLOCK_SEGMENT_COMPONENT = "NMD_N01_CLOCK";

--- a/hl7v22/segment_component_nmd_n01_clock_and_stats_with_notes.bal
+++ b/hl7v22/segment_component_nmd_n01_clock_and_stats_with_notes.bal
@@ -24,7 +24,7 @@ public type NMD_N01_CLOCK_AND_STATS_WITH_NOTES record {
     *hl7v2:SegmentComponent;
     string name = NMD_N01_CLOCK_AND_STATS_WITH_NOTES_SEGMENT_COMPONENT;
     boolean isRequired = true;
-    NMD_N01_CLOCK clock = {nck: {}};
+    NMD_N01_CLOCK nmd_n01_clock?;
 };
 
 public const NMD_N01_CLOCK_AND_STATS_WITH_NOTES_SEGMENT_COMPONENT = "NMD_N01_CLOCK_AND_STATS_WITH_NOTES";

--- a/hl7v22/segment_component_nmq_n02_qry_with_detail.bal
+++ b/hl7v22/segment_component_nmq_n02_qry_with_detail.bal
@@ -26,7 +26,7 @@ public type NMQ_N02_QRY_WITH_DETAIL record {
     boolean isRequired = false;
     QRD qrd = {};
     QRF qrf?;
-    NMQ_N02_CLOCK_AND_STATISTICS[] clock_and_statistics = [{}];
+    NMQ_N02_CLOCK_AND_STATISTICS[] nmq_n02_clock_and_statistics = [{}];
 };
 
 public const NMQ_N02_QRY_WITH_DETAIL_SEGMENT_COMPONENT = "NMQ_N02_QRY_WITH_DETAIL";

--- a/hl7v22/segment_component_orf_r04_order.bal
+++ b/hl7v22/segment_component_orf_r04_order.bal
@@ -27,7 +27,7 @@ public type ORF_R04_ORDER record {
     ORC orc?;
     OBR obr = {};
     NTE[] nte = [];
-    ORF_R04_OBSERVATION[] observation = [{}];
+    ORF_R04_OBSERVATION[] orf_r04_observation = [{}];
 };
 
 public const ORF_R04_ORDER_SEGMENT_COMPONENT = "ORF_R04_ORDER";

--- a/hl7v22/segment_component_orf_r04_query_response.bal
+++ b/hl7v22/segment_component_orf_r04_query_response.bal
@@ -28,7 +28,7 @@ public type ORF_R04_QUERY_RESPONSE record {
     QRF qrf?;
     PID pid?;
     NTE[] nte = [];
-    ORF_R04_ORDER[] 'order = [{obr: {}}];
+    ORF_R04_ORDER[] orf_r04_order = [{obr: {}}];
 };
 
 public const ORF_R04_QUERY_RESPONSE_SEGMENT_COMPONENT = "ORF_R04_QUERY_RESPONSE";

--- a/hl7v22/segment_component_orm_o01_order.bal
+++ b/hl7v22/segment_component_orm_o01_order.bal
@@ -25,7 +25,7 @@ public type ORM_O01_ORDER record {
     string name = ORM_O01_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    ORM_O01_ORDER_DETAIL order_detail?;
+    ORM_O01_ORDER_DETAIL orm_o01_order_detail?;
     BLG blg?;
 };
 

--- a/hl7v22/segment_component_orm_o01_order_detail.bal
+++ b/hl7v22/segment_component_orm_o01_order_detail.bal
@@ -24,9 +24,9 @@ public type ORM_O01_ORDER_DETAIL record {
     *hl7v2:SegmentComponent;
     string name = ORM_O01_ORDER_DETAIL_SEGMENT_COMPONENT;
     boolean isRequired = false;
-    ORM_O01_ORDER_DETAIL_SEGMENT order_detail_segment = {};
+    ORM_O01_ORDER_DETAIL_SEGMENT orm_o01_order_detail_segment = {};
     NTE[] nte = [];
-    ORM_O01_OBSERVATION[] observation = [];
+    ORM_O01_OBSERVATION[] orm_o01_observation = [];
 };
 
 public const ORM_O01_ORDER_DETAIL_SEGMENT_COMPONENT = "ORM_O01_ORDER_DETAIL";

--- a/hl7v22/segment_component_orr_o02_order.bal
+++ b/hl7v22/segment_component_orr_o02_order.bal
@@ -25,7 +25,7 @@ public type ORR_O02_ORDER record {
     string name = ORR_O02_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    ORR_O02_ORDER_DETAIL order_detail?;
+    ORR_O02_ORDER_DETAIL orr_o02_order_detail?;
 };
 
 public const ORR_O02_ORDER_SEGMENT_COMPONENT = "ORR_O02_ORDER";

--- a/hl7v22/segment_component_orr_o02_order_detail.bal
+++ b/hl7v22/segment_component_orr_o02_order_detail.bal
@@ -24,7 +24,7 @@ public type ORR_O02_ORDER_DETAIL record {
     *hl7v2:SegmentComponent;
     string name = ORR_O02_ORDER_DETAIL_SEGMENT_COMPONENT;
     boolean isRequired = false;
-    ORR_O02_ORDER_DETAIL_SEGMENT order_detail_segment?;
+    ORR_O02_ORDER_DETAIL_SEGMENT orr_o02_order_detail_segment?;
     NTE[] nte = [];
 };
 

--- a/hl7v22/segment_component_orr_o02_patient.bal
+++ b/hl7v22/segment_component_orr_o02_patient.bal
@@ -26,7 +26,7 @@ public type ORR_O02_PATIENT record {
     boolean isRequired = false;
     PID pid?;
     NTE[] nte = [];
-    ORR_O02_ORDER[] 'order = [{orc: {}}];
+    ORR_O02_ORDER[] orr_o02_order = [{orc: {}}];
 };
 
 public const ORR_O02_PATIENT_SEGMENT_COMPONENT = "ORR_O02_PATIENT";

--- a/hl7v22/segment_component_oru_r01_order_observation.bal
+++ b/hl7v22/segment_component_oru_r01_order_observation.bal
@@ -27,7 +27,7 @@ public type ORU_R01_ORDER_OBSERVATION record {
     ORC orc?;
     OBR obr = {};
     NTE[] nte = [];
-    ORU_R01_OBSERVATION[] observation = [{}];
+    ORU_R01_OBSERVATION[] oru_r01_observation = [{}];
 };
 
 public const ORU_R01_ORDER_OBSERVATION_SEGMENT_COMPONENT = "ORU_R01_ORDER_OBSERVATION";

--- a/hl7v22/segment_component_oru_r01_patient_result.bal
+++ b/hl7v22/segment_component_oru_r01_patient_result.bal
@@ -24,8 +24,8 @@ public type ORU_R01_PATIENT_RESULT record {
     *hl7v2:SegmentComponent;
     string name = ORU_R01_PATIENT_RESULT_SEGMENT_COMPONENT;
     boolean isRequired = true;
-    ORU_R01_PATIENT patient = {pid: {}};
-    ORU_R01_ORDER_OBSERVATION[] order_observation = [{obr: {}}];
+    ORU_R01_PATIENT oru_r01_patient?;
+    ORU_R01_ORDER_OBSERVATION[] oru_r01_order_observation = [{obr: {}}];
 };
 
 public const ORU_R01_PATIENT_RESULT_SEGMENT_COMPONENT = "ORU_R01_PATIENT_RESULT";

--- a/hl7v22/segment_component_rar_rar_definition.bal
+++ b/hl7v22/segment_component_rar_rar_definition.bal
@@ -26,8 +26,8 @@ public type RAR_RAR_DEFINITION record {
     boolean isRequired = true;
     QRD qrd = {};
     QRF qrf?;
-    RAR_RAR_PATIENT patient = {pid: {}};
-    RAR_RAR_ORDER[] 'order = [{orc: {}}];
+    RAR_RAR_PATIENT rar_rar_patient?;
+    RAR_RAR_ORDER[] rar_rar_order = [{orc: {}, rxa: [{}]}];
 };
 
 public const RAR_RAR_DEFINITION_SEGMENT_COMPONENT = "RAR_RAR_DEFINITION";

--- a/hl7v22/segment_component_rar_rar_order.bal
+++ b/hl7v22/segment_component_rar_rar_order.bal
@@ -25,7 +25,7 @@ public type RAR_RAR_ORDER record {
     string name = RAR_RAR_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RAR_RAR_ENCODING encoding = {rxe: {}};
+    RAR_RAR_ENCODING rar_rar_encoding?;
     RXA[] rxa = [{}];
 };
 

--- a/hl7v22/segment_component_ras_o02_order.bal
+++ b/hl7v22/segment_component_ras_o02_order.bal
@@ -25,11 +25,11 @@ public type RAS_O02_ORDER record {
     string name = RAS_O02_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RAS_O02_ORDER_DETAIL order_detail = {rxo: {}};
-    RAS_O02_ENCODING encoding = {rxe: {}};
+    RAS_O02_ORDER_DETAIL ras_o02_order_detail?;
+    RAS_O02_ENCODING ras_o02_encoding?;
     RXA[] rxa = [{}];
     RXR rxr = {};
-    RAS_O02_OBSERVATION[] observation = [];
+    RAS_O02_OBSERVATION[] ras_o02_observation = [];
 };
 
 public const RAS_O02_ORDER_SEGMENT_COMPONENT = "RAS_O02_ORDER";

--- a/hl7v22/segment_component_ras_o02_order_detail.bal
+++ b/hl7v22/segment_component_ras_o02_order_detail.bal
@@ -25,7 +25,7 @@ public type RAS_O02_ORDER_DETAIL record {
     string name = RAS_O02_ORDER_DETAIL_SEGMENT_COMPONENT;
     boolean isRequired = false;
     RXO rxo = {};
-    RAS_O02_ORDER_DETAIL_SUPPLEMENT order_detail_supplement = {nte: [{}]};
+    RAS_O02_ORDER_DETAIL_SUPPLEMENT ras_o02_order_detail_supplement?;
 };
 
 public const RAS_O02_ORDER_DETAIL_SEGMENT_COMPONENT = "RAS_O02_ORDER_DETAIL";

--- a/hl7v22/segment_component_ras_o02_order_detail_supplement.bal
+++ b/hl7v22/segment_component_ras_o02_order_detail_supplement.bal
@@ -26,7 +26,7 @@ public type RAS_O02_ORDER_DETAIL_SUPPLEMENT record {
     boolean isRequired = false;
     NTE[] nte = [{}];
     RXR[] rxr = [{}];
-    RAS_O02_COMPONENTS components = {rxc: [{}]};
+    RAS_O02_COMPONENTS ras_o02_components?;
 };
 
 public const RAS_O02_ORDER_DETAIL_SUPPLEMENT_SEGMENT_COMPONENT = "RAS_O02_ORDER_DETAIL_SUPPLEMENT";

--- a/hl7v22/segment_component_rde_o01_order.bal
+++ b/hl7v22/segment_component_rde_o01_order.bal
@@ -25,11 +25,11 @@ public type RDE_O01_ORDER record {
     string name = RDE_O01_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RDE_O01_ORDER_DETAIL order_detail = {rxo: {}};
+    RDE_O01_ORDER_DETAIL rde_o01_order_detail?;
     RXE rxe = {};
     RXR[] rxr = [{}];
     RXC[] rxc = [];
-    RDE_O01_OBSERVATION[] observation = [{}];
+    RDE_O01_OBSERVATION[] rde_o01_observation = [{}];
 };
 
 public const RDE_O01_ORDER_SEGMENT_COMPONENT = "RDE_O01_ORDER";

--- a/hl7v22/segment_component_rde_o01_order_detail.bal
+++ b/hl7v22/segment_component_rde_o01_order_detail.bal
@@ -27,7 +27,7 @@ public type RDE_O01_ORDER_DETAIL record {
     RXO rxo = {};
     NTE[] nte = [];
     RXR[] rxr = [{}];
-    RDE_O01_COMPONENT component = {rxc: [{}]};
+    RDE_O01_COMPONENT rde_o01_component?;
 };
 
 public const RDE_O01_ORDER_DETAIL_SEGMENT_COMPONENT = "RDE_O01_ORDER_DETAIL";

--- a/hl7v22/segment_component_rdr_rdr_definition.bal
+++ b/hl7v22/segment_component_rdr_rdr_definition.bal
@@ -26,8 +26,8 @@ public type RDR_RDR_DEFINITION record {
     boolean isRequired = true;
     QRD qrd = {};
     QRF qrf?;
-    RDR_RDR_PATIENT patient = {pid: {}};
-    RDR_RDR_ORDER[] 'order = [{orc: {}}];
+    RDR_RDR_PATIENT rdr_rdr_patient?;
+    RDR_RDR_ORDER[] rdr_rdr_order = [{orc: {}, rdr_rdr_dispense: [{rxd: {}, rxr: [{}]}]}];
 };
 
 public const RDR_RDR_DEFINITION_SEGMENT_COMPONENT = "RDR_RDR_DEFINITION";

--- a/hl7v22/segment_component_rdr_rdr_order.bal
+++ b/hl7v22/segment_component_rdr_rdr_order.bal
@@ -25,8 +25,8 @@ public type RDR_RDR_ORDER record {
     string name = RDR_RDR_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RDR_RDR_ENCODING encoding = {rxe: {}};
-    RDR_RDR_DISPENSE[] dispense = [{rxd: {}}];
+    RDR_RDR_ENCODING rdr_rdr_encoding?;
+    RDR_RDR_DISPENSE[] rdr_rdr_dispense = [{rxd: {}, rxr: [{}]}];
 };
 
 public const RDR_RDR_ORDER_SEGMENT_COMPONENT = "RDR_RDR_ORDER";

--- a/hl7v22/segment_component_rds_o01_order.bal
+++ b/hl7v22/segment_component_rds_o01_order.bal
@@ -25,12 +25,12 @@ public type RDS_O01_ORDER record {
     string name = RDS_O01_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RDS_O01_ORDER_DETAIL order_detail = {rxo: {}};
-    RDS_O01_ENCODING encoding = {rxe: {}};
+    RDS_O01_ORDER_DETAIL rds_o01_order_detail?;
+    RDS_O01_ENCODING rds_o01_encoding?;
     RXD rxd = {};
     RXR[] rxr = [{}];
     RXE[] rxe = [];
-    RDS_O01_OBSERVATION[] observation = [{}];
+    RDS_O01_OBSERVATION[] rds_o01_observation = [{}];
 };
 
 public const RDS_O01_ORDER_SEGMENT_COMPONENT = "RDS_O01_ORDER";

--- a/hl7v22/segment_component_rds_o01_order_detail.bal
+++ b/hl7v22/segment_component_rds_o01_order_detail.bal
@@ -25,7 +25,7 @@ public type RDS_O01_ORDER_DETAIL record {
     string name = RDS_O01_ORDER_DETAIL_SEGMENT_COMPONENT;
     boolean isRequired = false;
     RXO rxo = {};
-    RDS_O01_ORDER_DETAIL_SUPPLEMENT order_detail_supplement = {nte: [{}]};
+    RDS_O01_ORDER_DETAIL_SUPPLEMENT rds_o01_order_detail_supplement?;
 };
 
 public const RDS_O01_ORDER_DETAIL_SEGMENT_COMPONENT = "RDS_O01_ORDER_DETAIL";

--- a/hl7v22/segment_component_rds_o01_order_detail_supplement.bal
+++ b/hl7v22/segment_component_rds_o01_order_detail_supplement.bal
@@ -26,7 +26,7 @@ public type RDS_O01_ORDER_DETAIL_SUPPLEMENT record {
     boolean isRequired = false;
     NTE[] nte = [{}];
     RXR[] rxr = [{}];
-    RDS_O01_COMPONENT component = {rxc: [{}]};
+    RDS_O01_COMPONENT rds_o01_component?;
 };
 
 public const RDS_O01_ORDER_DETAIL_SUPPLEMENT_SEGMENT_COMPONENT = "RDS_O01_ORDER_DETAIL_SUPPLEMENT";

--- a/hl7v22/segment_component_rer_rer_definition.bal
+++ b/hl7v22/segment_component_rer_rer_definition.bal
@@ -26,8 +26,8 @@ public type RER_RER_DEFINITION record {
     boolean isRequired = true;
     QRD qrd = {};
     QRF qrf?;
-    RER_RER_PATIENT patient = {pid: {}};
-    RER_RER_ORDER[] 'order = [{orc: {}}];
+    RER_RER_PATIENT rer_rer_patient?;
+    RER_RER_ORDER[] rer_rer_order = [{orc: {}, rxe: {}, rxr: [{}]}];
 };
 
 public const RER_RER_DEFINITION_SEGMENT_COMPONENT = "RER_RER_DEFINITION";

--- a/hl7v22/segment_component_rgr_rgr_definition.bal
+++ b/hl7v22/segment_component_rgr_rgr_definition.bal
@@ -26,8 +26,8 @@ public type RGR_RGR_DEFINITION record {
     boolean isRequired = true;
     QRD qrd = {};
     QRF qrf?;
-    RGR_RGR_PATIENT patient = {pid: {}};
-    RGR_RGR_ORDER[] 'order = [{orc: {}}];
+    RGR_RGR_PATIENT rgr_rgr_patient?;
+    RGR_RGR_ORDER[] rgr_rgr_order = [{orc: {}, rxg: [{}], rxr: [{}]}];
 };
 
 public const RGR_RGR_DEFINITION_SEGMENT_COMPONENT = "RGR_RGR_DEFINITION";

--- a/hl7v22/segment_component_rgr_rgr_order.bal
+++ b/hl7v22/segment_component_rgr_rgr_order.bal
@@ -25,7 +25,7 @@ public type RGR_RGR_ORDER record {
     string name = RGR_RGR_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RGR_RGR_ENCODING encoding = {rxe: {}};
+    RGR_RGR_ENCODING rgr_rgr_encoding?;
     RXG[] rxg = [{}];
     RXR[] rxr = [{}];
 };

--- a/hl7v22/segment_component_rgv_o01_give.bal
+++ b/hl7v22/segment_component_rgv_o01_give.bal
@@ -27,7 +27,7 @@ public type RGV_O01_GIVE record {
     RXG rxg = {};
     RXR[] rxr = [{}];
     RXC[] rxc = [];
-    RGV_O01_OBSERVATION observation = {};
+    RGV_O01_OBSERVATION rgv_o01_observation = {};
 };
 
 public const RGV_O01_GIVE_SEGMENT_COMPONENT = "RGV_O01_GIVE";

--- a/hl7v22/segment_component_rgv_o01_order.bal
+++ b/hl7v22/segment_component_rgv_o01_order.bal
@@ -25,9 +25,9 @@ public type RGV_O01_ORDER record {
     string name = RGV_O01_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RGV_O01_ORDER_DETAIL order_detail = {rxo: {}};
-    RGV_O01_ENCODING encoding = {rxe: {}};
-    RGV_O01_GIVE give = {rxg: {}};
+    RGV_O01_ORDER_DETAIL rgv_o01_order_detail?;
+    RGV_O01_ENCODING rgv_o01_encoding?;
+    RGV_O01_GIVE rgv_o01_give = {rxg: {}, rxr: [{}]};
 };
 
 public const RGV_O01_ORDER_SEGMENT_COMPONENT = "RGV_O01_ORDER";

--- a/hl7v22/segment_component_rgv_o01_order_detail.bal
+++ b/hl7v22/segment_component_rgv_o01_order_detail.bal
@@ -25,7 +25,7 @@ public type RGV_O01_ORDER_DETAIL record {
     string name = RGV_O01_ORDER_DETAIL_SEGMENT_COMPONENT;
     boolean isRequired = false;
     RXO rxo = {};
-    RGV_O01_ORDER_DETAIL_SUPPLEMENT order_detail_supplement = {nte: [{}]};
+    RGV_O01_ORDER_DETAIL_SUPPLEMENT rgv_o01_order_detail_supplement?;
 };
 
 public const RGV_O01_ORDER_DETAIL_SEGMENT_COMPONENT = "RGV_O01_ORDER_DETAIL";

--- a/hl7v22/segment_component_rgv_o01_order_detail_supplement.bal
+++ b/hl7v22/segment_component_rgv_o01_order_detail_supplement.bal
@@ -26,7 +26,7 @@ public type RGV_O01_ORDER_DETAIL_SUPPLEMENT record {
     boolean isRequired = false;
     NTE[] nte = [{}];
     RXR[] rxr = [{}];
-    RGV_O01_COMPONENT component = {rxc: [{}]};
+    RGV_O01_COMPONENT rgv_o01_component?;
 };
 
 public const RGV_O01_ORDER_DETAIL_SUPPLEMENT_SEGMENT_COMPONENT = "RGV_O01_ORDER_DETAIL_SUPPLEMENT";

--- a/hl7v22/segment_component_ror_ror_definition.bal
+++ b/hl7v22/segment_component_ror_ror_definition.bal
@@ -26,8 +26,8 @@ public type ROR_ROR_DEFINITION record {
     boolean isRequired = true;
     QRD qrd = {};
     QRF qrf?;
-    ROR_ROR_PATIENT patient = {pid: {}};
-    ROR_ROR_ORDER[] 'order = [{orc: {}}];
+    ROR_ROR_PATIENT ror_ror_patient?;
+    ROR_ROR_ORDER[] ror_ror_order = [{orc: {}, rxo: {}, rxr: [{}]}];
 };
 
 public const ROR_ROR_DEFINITION_SEGMENT_COMPONENT = "ROR_ROR_DEFINITION";

--- a/hl7v22/segment_component_rra_o02_order.bal
+++ b/hl7v22/segment_component_rra_o02_order.bal
@@ -25,7 +25,7 @@ public type RRA_O02_ORDER record {
     string name = RRA_O02_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RRA_O02_ADMINISTRATION[] administration = [];
+    RRA_O02_ADMINISTRATION[] rra_o02_administration = [];
 };
 
 public const RRA_O02_ORDER_SEGMENT_COMPONENT = "RRA_O02_ORDER";

--- a/hl7v22/segment_component_rra_o02_response.bal
+++ b/hl7v22/segment_component_rra_o02_response.bal
@@ -24,8 +24,8 @@ public type RRA_O02_RESPONSE record {
     *hl7v2:SegmentComponent;
     string name = RRA_O02_RESPONSE_SEGMENT_COMPONENT;
     boolean isRequired = false;
-    RRA_O02_PATIENT patient = {pid: {}};
-    RRA_O02_ORDER[] 'order = [{orc: {}}];
+    RRA_O02_PATIENT rra_o02_patient?;
+    RRA_O02_ORDER[] rra_o02_order = [{orc: {}}];
 };
 
 public const RRA_O02_RESPONSE_SEGMENT_COMPONENT = "RRA_O02_RESPONSE";

--- a/hl7v22/segment_component_rrd_o02_order.bal
+++ b/hl7v22/segment_component_rrd_o02_order.bal
@@ -25,7 +25,7 @@ public type RRD_O02_ORDER record {
     string name = RRD_O02_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RRD_O02_ORDER_DETAIL order_detail = {rxd: {}};
+    RRD_O02_ORDER_DETAIL rrd_o02_order_detail?;
 };
 
 public const RRD_O02_ORDER_SEGMENT_COMPONENT = "RRD_O02_ORDER";

--- a/hl7v22/segment_component_rrd_o02_patient.bal
+++ b/hl7v22/segment_component_rrd_o02_patient.bal
@@ -26,7 +26,7 @@ public type RRD_O02_PATIENT record {
     boolean isRequired = false;
     PID pid?;
     NTE[] nte = [];
-    RRD_O02_ORDER[] 'order = [{orc: {}}];
+    RRD_O02_ORDER[] rrd_o02_order = [{orc: {}}];
 };
 
 public const RRD_O02_PATIENT_SEGMENT_COMPONENT = "RRD_O02_PATIENT";

--- a/hl7v22/segment_component_rre_o02_order.bal
+++ b/hl7v22/segment_component_rre_o02_order.bal
@@ -25,7 +25,7 @@ public type RRE_O02_ORDER record {
     string name = RRE_O02_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RRE_O02_ORDER_DETAIL order_detail = {rxe: {}};
+    RRE_O02_ORDER_DETAIL rre_o02_order_detail?;
 };
 
 public const RRE_O02_ORDER_SEGMENT_COMPONENT = "RRE_O02_ORDER";

--- a/hl7v22/segment_component_rre_o02_patient.bal
+++ b/hl7v22/segment_component_rre_o02_patient.bal
@@ -26,7 +26,7 @@ public type RRE_O02_PATIENT record {
     boolean isRequired = false;
     PID pid?;
     NTE[] nte = [];
-    RRE_O02_ORDER[] 'order = [{orc: {}}];
+    RRE_O02_ORDER[] rre_o02_order = [{orc: {}}];
 };
 
 public const RRE_O02_PATIENT_SEGMENT_COMPONENT = "RRE_O02_PATIENT";

--- a/hl7v22/segment_component_rrg_o02_order.bal
+++ b/hl7v22/segment_component_rrg_o02_order.bal
@@ -25,7 +25,7 @@ public type RRG_O02_ORDER record {
     string name = RRG_O02_ORDER_SEGMENT_COMPONENT;
     boolean isRequired = true;
     ORC orc = {};
-    RRG_O02_ORDER_DETAIL order_detail = {rxg: {}};
+    RRG_O02_ORDER_DETAIL rrg_o02_order_detail?;
 };
 
 public const RRG_O02_ORDER_SEGMENT_COMPONENT = "RRG_O02_ORDER";

--- a/hl7v22/segment_component_rrg_o02_patient.bal
+++ b/hl7v22/segment_component_rrg_o02_patient.bal
@@ -26,7 +26,7 @@ public type RRG_O02_PATIENT record {
     boolean isRequired = false;
     PID pid?;
     NTE[] nte = [];
-    RRG_O02_ORDER[] 'order = [{orc: {}}];
+    RRG_O02_ORDER[] rrg_o02_order = [{orc: {}}];
 };
 
 public const RRG_O02_PATIENT_SEGMENT_COMPONENT = "RRG_O02_PATIENT";


### PR DESCRIPTION
## Purpose
> $Subject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request addresses segment group naming issues and improves compatibility with other versions of the HL7v2 standard library. The changes standardize naming conventions across the hl7v22 message definitions module and update message structure initialization to be more explicit and accurate.

### Key Changes

**Dependency Update:**
- Updated `ballerinax:health.hl7v2` dependency from version 3.0.9 to 3.0.10

**Segment Group Naming Standardization:**
The PR systematically renames segment group fields across 40+ segment component and message definition files to follow a consistent naming convention. Generic field names (e.g., `order`, `patient`, `insurance`, `observation`) are prefixed with their message or component type (e.g., `orr_o02_order`, `rar_rar_patient`, `adr_a19_insurance`, `oru_r01_observation`). This prevents naming collisions and improves clarity when multiple segment groups have similar structures.

**Message Definition Initialization:**
Message definitions are updated to include more complete default structures for nested segment groups. For example:
- Query response groups now include full object initialization with multiple segment types
- Order groups are initialized with all required sub-segments (e.g., ORC, RXE, RXR)
- Dispense and observation groups include proper nested structure initialization

**Field Declaration Adjustments:**
Several component fields are refactored from required fields with default values to optional fields (`?`), allowing for more flexible message structures that better align with actual HL7v2 message specifications. This provides better compatibility with messages that may omit certain optional components.

### Impact

These changes improve consistency across the codebase, reduce the likelihood of naming conflicts, and create message definitions that are more compatible with other HL7v2 implementations. The refactoring maintains backward compatibility in terms of message structure while clarifying the intended composition of nested segment groups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerinax-health.hl7v2/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->